### PR TITLE
DebugPrint

### DIFF
--- a/Build/gcc/Makefile
+++ b/Build/gcc/Makefile
@@ -90,7 +90,7 @@ CXXFLAGS = $(DEPENDENCY_FLAGS) $(INCLUDE_FLAGS) \
            -std=c++11 -Wall -fPIC -pthread
 
 # Debug target logic.
-debug: CXXFLAGS += -g3
+debug: CXXFLAGS += -g3 -DORCHESTRATOR_DEBUG=1
 debug: all
 
 # Handy aliases for building executables, scripts, and libraries. Order doesn't

--- a/Build/gcc/Makefile.prerequisites
+++ b/Build/gcc/Makefile.prerequisites
@@ -172,7 +172,8 @@ MOTHERSHIP_SOURCES = $(SOURCE_DIR)/Mothership/MothershipMain.cpp \
                      $(SOURCE_DIR)/OrchBase/P_message.cpp \
                      $(SOURCE_DIR)/OrchBase/P_pin.cpp \
                      $(SOURCE_DIR)/OrchBase/P_task.cpp \
-                     $(SOURCE_DIR)/OrchBase/P_thread.cpp
+                     $(SOURCE_DIR)/OrchBase/P_thread.cpp \
+                     $(SOURCE_DIR)/Common/Debug.cpp
 
 MOTHERSHIP_SOURCES += $(TRULY_COMMON_SOURCES)
 

--- a/Source/Common/Debug.cpp
+++ b/Source/Common/Debug.cpp
@@ -1,0 +1,25 @@
+/* See the accompanying header for more information on what this does. */
+#include "Debug.h"
+
+/* ORCHESTRATOR_DEBUG should be defined by the compiler invocation if
+ * debug-printing is desired. If it's not defined by the compiler, we assume
+ * the user does not want it. */
+#ifndef ORCHESTRATOR_DEBUG
+#define ORCHESTRATOR_DEBUG 0
+#endif
+
+/* If we're debugging, DebugPrint writes the message to stdout (with
+ * formatting). Otherwise, DebugPrint does nothing. */
+#if ORCHESTRATOR_DEBUG
+#include <stdarg.h>
+#include <stdio.h>
+void DebugPrint(const char* format, ...)
+{
+    va_list printingArguments;
+    va_start(printingArguments, format);
+    vfprintf(stdout, format, printingArguments);
+    fflush(stdout);
+}
+#else
+void DebugPrint(const char*, ...){return;}
+#endif

--- a/Source/Common/Debug.h
+++ b/Source/Common/Debug.h
@@ -1,0 +1,7 @@
+#ifndef __ORCHESTRATOR_SOURCE_COMMON_DEBUG_H
+#define __ORCHESTRATOR_SOURCE_COMMON_DEBUG_H
+/* This header-source pair defines a simple print-debug method, which does
+ * nothing if the environment variable ORCHESTRATOR_DEBUG is not true, and
+ * writes to standard output otherwise. */
+void DebugPrint(const char*, ...);
+#endif

--- a/Source/Mothership/TMoth.h
+++ b/Source/Mothership/TMoth.h
@@ -3,6 +3,7 @@
 
 #include <deque>
 #include "CommonBase.h"
+#include "Debug.h"
 #include "PMsg_p.hpp"
 #include "Cli.h"
 #include "HostLink.h"

--- a/Source/Mothership/TaskInfo.cpp
+++ b/Source/Mothership/TaskInfo.cpp
@@ -54,8 +54,7 @@ void TaskInfo_t::insertCore(uint32_t vCore, P_addr_t coreID)
        VirtualBox = new P_box(0);
        VirtualBox->AutoName(TaskName+"_Box_");
        VirtualBox->addr.A_box = coreID.A_box;
-       printf("Inserting VirtualBox %s\n",VirtualBox->Name().c_str());
-       fflush(stdout);
+       DebugPrint("Inserting VirtualBox %s\n",VirtualBox->Name().c_str());
     }
     if (coreID.A_box != VirtualBox->addr.A_box) return; // not our box. Ignore.
     P_board* VirtualBoard = 0;
@@ -63,8 +62,7 @@ void TaskInfo_t::insertCore(uint32_t vCore, P_addr_t coreID)
     {
        if ((*B)->addr.A_board == coreID.A_board)
        {
-	  printf("Using VirtualBoard %s\n",(*B)->Name().c_str());
-          fflush(stdout);	  
+	  DebugPrint("Using VirtualBoard %s\n",(*B)->Name().c_str());
 	  VirtualBoard = (*B);
 	  break;
        }
@@ -76,8 +74,7 @@ void TaskInfo_t::insertCore(uint32_t vCore, P_addr_t coreID)
        VirtualBoard->AutoName(VirtualBox->Name()+"_Board_");
        VirtualBoard->addr.A_box = coreID.A_box;
        VirtualBoard->addr.A_board = coreID.A_board;
-       printf("Inserting VirtualBoard %s\n",VirtualBoard->Name().c_str());
-       fflush(stdout);
+       DebugPrint("Inserting VirtualBoard %s\n",VirtualBoard->Name().c_str());
     }
     softMap_t::iterator C = VCoreMap.find(vCore);
     if (C != VCoreMap.end())

--- a/Source/Mothership/TaskInfo.h
+++ b/Source/Mothership/TaskInfo.h
@@ -1,6 +1,7 @@
 #ifndef __TASKINFO_H__
 #define __TASKINFO_H__
 
+#include "Debug.h"
 #include "P_task.h"
 #include "P_box.h"
 #include "P_board.h"


### PR DESCRIPTION
Link to issue: #44 

This changeset introduces the `DebugPrint(const char*, ...)` method, which allows developers to include messages in their source to help other developers at run-time. When the Orchestrator is built with `make debug` (or when the compiler sets `ORCHESTRATOR_DEBUG` to a true value), DebugPrint acts as `printf(const char*, ...); fflush(stdout)`. When the Orchestrator is build with `make all` (or when the compiler sets `ORCHESTRATOR_DEBUG` to a false value, or leaves it unset), DebugPrint is stubbed.

This changeset replaces commented printfs and fflushes with DebugPrints in the Mothership.

Object dump (using `nm`) when DebugPrint is not stubbed:

```
                 U fflush
                 U _GLOBAL_OFFSET_TABLE_
                 U __stack_chk_fail
                 U stdout
                 U vfprintf
0000000000000000 n wm4.0.35fe6650b983e39b52572616bbc00579
0000000000000000 n wm4.cdefs.h.19.4bfdec6e8eda1b86e0663d7c32c234f0
0000000000000000 n wm4.cdefs.h.465.a3fa96cf8f9dfc66216e727a78777498
0000000000000000 n wm4.features.h.19.7cef3c703ca82c4d8dda3cfae7bf9667
0000000000000000 n wm4.libcheaderstart.h.37.4783d5b827b19ea444d0c15885193a21
0000000000000000 n wm4.stdarg.h.31.b55da1089056868966f25de5dbfc7d3c
0000000000000000 n wm4.stdcpredef.h.19.8dc41bed5d9037ff9622e015fb5f0ce3
0000000000000000 n wm4.stddef.h.187.422da5f95ac1285e95faf42258f23242
0000000000000000 n wm4.stdio.h.141.b0c94cfe85e47c3e04fb2ad92e608937
0000000000000000 n wm4.stdio.h.24.5c1b97eef3c86b7a2549420f69f4f128
0000000000000000 n wm4.stdio.h.31.e39a94e203ad4e1d978c0fc68ce016ee
0000000000000000 n wm4.stdio.h.67.12185a2718878572bb08c7ddc284899f
0000000000000000 n wm4.stdio_lim.h.19.86760ef34d2b7513aac6ce30cb73c6f8
0000000000000000 n wm4.struct_FILE.h.19.0888ac70396abe1031c03d393554032f
0000000000000000 n wm4.stubs64.h.10.918ceb5fa58268542bf143e4c1efbcf3
0000000000000000 n wm4.types.h.108.df524432123d742a55477fc8c4446826
0000000000000000 n wm4.typesizes.h.24.292526668b3d7d0c797f011b553fed17
0000000000000000 n wm4.wordsize.h.4.baf119258a1e53d8dba67ceac44ab6bc
0000000000000000 T _Z10DebugPrintPKcz
```

Object dump when DebugPrint is stubbed:

```
0000000000000000 T _Z10DebugPrintPKcz
```

Edit: Both the on and off cases were tested on Coleridge with the following test script (using `call /file`):

```
task /path = "/home/mark/repos/orchestrator/application_staging/xml"
task /load = "plate_3x3_examples_repo_4cfc9f79098e0a45cee6e129ddab575d9b8066e2.xml"
topology /set1
link /link = "plate_3x3"
task /build = "plate_3x3"
task /deploy = "plate_3x3"
task /init = "plate_3x3"
task /run = "plate_3x3"
```

Edit: would help if I attached the XML! It's a Gist here: https://gist.github.com/mvousden/a2aa0f60333f131c2045e66cca5eb599