### PR TITLE
Software Address

### DIFF
--- a/Build/gcc/Makefile.executable_prerequisites
+++ b/Build/gcc/Makefile.executable_prerequisites
@@ -26,9 +26,9 @@ TRULY_COMMON_SOURCES = $(SOURCE_DIR)/Common/CommonBase.cpp \
                        $(GENERICS_DIR)/Msg_p.cpp
 
 # Sources used by executables that need to address hardware.
-HARDWARE_ADDRESS_SOURCES = $(SOURCE_DIR)/Common/HardwareModel/HardwareDumpUtils.cpp \
-                           $(SOURCE_DIR)/Common/HardwareModel/HardwareAddress.cpp \
+HARDWARE_ADDRESS_SOURCES = $(SOURCE_DIR)/Common/HardwareModel/HardwareAddress.cpp \
                            $(SOURCE_DIR)/Common/HardwareModel/HardwareAddressFormat.cpp \
+                           $(SOURCE_DIR)/Common/DumpUtils.cpp \
                            $(SOURCE_DIR)/OrchBase/P_addr.cpp \
                            $(GENERICS_DIR)/flat.cpp \
                            $(GENERICS_DIR)/dfprintf.cpp \
@@ -36,7 +36,6 @@ HARDWARE_ADDRESS_SOURCES = $(SOURCE_DIR)/Common/HardwareModel/HardwareDumpUtils.
 
 # Sources used by executables that require the hardware model.
 HARDWARE_MODEL_SOURCES = $(SOURCE_DIR)/Common/HardwareModel/AddressableItem.cpp \
-                         $(SOURCE_DIR)/Common/HardwareModel/HardwareDumpUtils.cpp \
                          $(SOURCE_DIR)/Common/HardwareModel/P_engine.cpp \
                          $(SOURCE_DIR)/Common/HardwareModel/P_box.cpp \
                          $(SOURCE_DIR)/Common/HardwareModel/P_board.cpp \
@@ -45,6 +44,7 @@ HARDWARE_MODEL_SOURCES = $(SOURCE_DIR)/Common/HardwareModel/AddressableItem.cpp 
                          $(SOURCE_DIR)/Common/HardwareModel/P_thread.cpp \
                          $(SOURCE_DIR)/Common/HardwareModel/P_link.cpp \
                          $(SOURCE_DIR)/Common/HardwareModel/P_port.cpp \
+                         $(SOURCE_DIR)/Common/DumpUtils.cpp \
                          $(SOURCE_DIR)/Common/NameBase.cpp \
                          $(SOURCE_DIR)/OrchBase/Bin.cpp \
                          $(GENERICS_DIR)/rand.cpp \

--- a/Build/gcc/Makefile.executable_prerequisites
+++ b/Build/gcc/Makefile.executable_prerequisites
@@ -25,6 +25,12 @@ TRULY_COMMON_SOURCES = $(SOURCE_DIR)/Common/CommonBase.cpp \
                        $(GENERICS_DIR)/flat.cpp \
                        $(GENERICS_DIR)/Msg_p.cpp
 
+# Sources used by executables that need software addresses.
+SOFTWARE_ADDRESS_SOURCES = $(SOURCE_DIR)/Common/SoftwareAddress.cpp \
+                           $(SOURCE_DIR)/Common/DumpUtils.cpp \
+                           $(GENERICS_DIR)/dfprintf.cpp \
+                           $(GENERICS_DIR)/dumpchan.cpp
+
 # Sources used by executables that need to address hardware.
 HARDWARE_ADDRESS_SOURCES = $(SOURCE_DIR)/Common/HardwareModel/HardwareAddress.cpp \
                            $(SOURCE_DIR)/Common/HardwareModel/HardwareAddressFormat.cpp \

--- a/Build/gcc/Makefile.test_prerequisites
+++ b/Build/gcc/Makefile.test_prerequisites
@@ -26,6 +26,7 @@ TestHardwareFileParser_SOURCES = $(HARDWARE_FILE_PARSER_SOURCES)
 TestHardwareIterator_SOURCES = $(HARDWARE_ITERATOR_SOURCES)
 TestHardwareModel_SOURCES = $(HARDWARE_MODEL_SOURCES)
 TestSimpleDeployment_SOURCES = $(HARDWARE_DEPLOYER_SOURCES)
+TestSoftwareAddress_SOURCES = $(SOFTWARE_ADDRESS_SOURCES)
 
 # Define test rules. TEST_RULE_TEMPLATE defines the substitutions made in the
 # foreach loop below.

--- a/Source/Common/DumpUtils.cpp
+++ b/Source/Common/DumpUtils.cpp
@@ -1,4 +1,4 @@
-#include "HardwareDumpUtils.h"
+#include "DumpUtils.h"
 
 /* Prints something like:
  *
@@ -17,7 +17,7 @@
  * - breakerSymbol: Symbol to use to construct the tail of the breaker.
  */
 
-namespace HardwareDumpUtils {
+namespace DumpUtils {
 
     void breaker(FILE* outPlace, const std::string& prefix, char breakerSymbol)
     {

--- a/Source/Common/DumpUtils.h
+++ b/Source/Common/DumpUtils.h
@@ -1,8 +1,7 @@
-#ifndef __ORCHESTRATOR_SOURCE_COMMON_HARDWARE_MODEL_HARDWAREDUMPUTILS_H
-#define __ORCHESTRATOR_SOURCE_COMMON_HARDWARE_MODEL_HARDWAREDUMPUTILS_H
+#ifndef __ORCHESTRATOR_SOURCE_COMMON_DUMPUTILS_H
+#define __ORCHESTRATOR_SOURCE_COMMON_DUMPUTILS_H
 
-/* Simple file to define some free functions to help with dumping the hardware
- * model. */
+/* Simple file to define some free functions to help with dumping things. */
 
 #include <algorithm>
 #include <stdio.h>
@@ -14,7 +13,7 @@
 #define MAXIMUM_BREAKER_LENGTH 80
 #define GRAPH_CALLBACK static void
 
-namespace HardwareDumpUtils {
+namespace DumpUtils {
     void breaker(FILE* outPlace, const std::string& prefix,
                  unsigned prefixLength, char breakerSymbol);
 

--- a/Source/Common/HardwareModel/HardwareAddress.cpp
+++ b/Source/Common/HardwareModel/HardwareAddress.cpp
@@ -190,7 +190,7 @@ void HardwareAddress::Dump(FILE* file)
 {
     std::string prefix = dformat("Hardware address at %#018lx",
                                  (uint64_t) this);
-    HardwareDumpUtils::open_breaker(file, prefix);
+    DumpUtils::open_breaker(file, prefix);
 
     /* Just contains the components, and whether or not they have been
      * defined. */
@@ -210,6 +210,6 @@ void HardwareAddress::Dump(FILE* file)
     fprintf(file, "%s\n", is_thread_defined() ? "" : "(not defined)");
 
     /* Close breaker and flush the dump. */
-    HardwareDumpUtils::close_breaker(file, prefix);
+    DumpUtils::close_breaker(file, prefix);
     fflush(file);
 }

--- a/Source/Common/HardwareModel/HardwareAddress.h
+++ b/Source/Common/HardwareModel/HardwareAddress.h
@@ -28,6 +28,14 @@
 #include "P_addr.h"
 #include <cmath>  /* For validating address components. */
 
+/* Define masks for setting the 'definitions' variable. */
+#define HARDWARE_ADDRESS_FULLY_DEFINED_MASK 31  /* 0b11111 */
+#define BOX_DEFINED_MASK 1                      /* 0b00001 */
+#define BOARD_DEFINED_MASK 2                    /* 0b00010 */
+#define MAILBOX_DEFINED_MASK 4                  /* 0b00100 */
+#define CORE_DEFINED_MASK 8                     /* 0b01000 */
+#define THREAD_DEFINED_MASK 16                  /* 0b10000 */
+
 /* Hardware address component representation. */
 typedef uint32_t AddressComponent;
 
@@ -68,14 +76,19 @@ public:
     void populate_from_software_address(P_addr* source);
     void Dump(FILE* = stdout);
 
-    /* Defines whether or not the hardware address is fully defined. No binary
-     * literal in C++98 (yuck). */
-    inline bool is_fully_defined(){return definitions == 31;}  /* 0b11111 */
-    inline bool is_box_defined(){return (definitions & 1) > 0;}
-    inline bool is_board_defined(){return (definitions & 2) > 0;}
-    inline bool is_mailbox_defined(){return (definitions & 4) > 0;}
-    inline bool is_core_defined(){return (definitions & 8) > 0;}
-    inline bool is_thread_defined(){return (definitions & 16) > 0;}
+    /* Defines whether or not the hardware address is fully defined. */
+    inline bool is_fully_defined()
+        {return definitions == HARDWARE_ADDRESS_FULLY_DEFINED_MASK;}
+    inline bool is_box_defined()
+        {return (definitions & BOX_DEFINED_MASK) > 0;}
+    inline bool is_board_defined()
+        {return (definitions & BOARD_DEFINED_MASK) > 0;}
+    inline bool is_mailbox_defined()
+        {return (definitions & MAILBOX_DEFINED_MASK) > 0;}
+    inline bool is_core_defined()
+        {return (definitions & CORE_DEFINED_MASK) > 0;}
+    inline bool is_thread_defined()
+        {return (definitions & THREAD_DEFINED_MASK) > 0;}
 
 private:
 

--- a/Source/Common/HardwareModel/HardwareAddress.h
+++ b/Source/Common/HardwareModel/HardwareAddress.h
@@ -22,8 +22,8 @@
  * See the hardware model documentation for further information about hardware
  * addresses. */
 
+#include "DumpUtils.h"
 #include "HardwareAddressFormat.h"
-#include "HardwareDumpUtils.h"
 #include "InvalidAddressException.h"
 #include "P_addr.h"
 #include <cmath>  /* For validating address components. */

--- a/Source/Common/HardwareModel/HardwareAddressFormat.cpp
+++ b/Source/Common/HardwareModel/HardwareAddressFormat.cpp
@@ -28,7 +28,7 @@ void HardwareAddressFormat::Dump(FILE* file)
 {
     std::string prefix = dformat("Hardware address format at %#018lx",
                                  (uint64_t) this);
-    HardwareDumpUtils::open_breaker(file, prefix);
+    DumpUtils::open_breaker(file, prefix);
 
     /* The dump basically just contains the lengths. */
     fprintf(file, "boxWordLength:     %u\n\
@@ -43,6 +43,6 @@ threadWordLength:  %u\n",
             threadWordLength);
 
     /* Close breaker and flush the dump. */
-    HardwareDumpUtils::close_breaker(file, prefix);
+    DumpUtils::close_breaker(file, prefix);
     fflush(file);
 }

--- a/Source/Common/HardwareModel/HardwareAddressFormat.h
+++ b/Source/Common/HardwareModel/HardwareAddressFormat.h
@@ -9,7 +9,7 @@
  * See the hardware model documentation for further information about the
  * format of hardware addresses. */
 
-#include "HardwareDumpUtils.h"
+#include "DumpUtils.h"
 
 class HardwareAddressFormat: public DumpChan
 {

--- a/Source/Common/HardwareModel/HardwareIterator.cpp
+++ b/Source/Common/HardwareModel/HardwareIterator.cpp
@@ -259,7 +259,7 @@ void HardwareIterator::reset_thread_iterator()
 void HardwareIterator::Dump(FILE* file)
 {
     std::string prefix = FullName();
-    HardwareDumpUtils::open_breaker(file, prefix);
+    DumpUtils::open_breaker(file, prefix);
 
     /* About this object. */
     NameBase::Dump(file);
@@ -301,6 +301,6 @@ void HardwareIterator::Dump(FILE* file)
     fprintf(file, "This iterator has%s wrapped.\n", isWrapped ? "" : " not");
 
     /* Close breaker and flush the dump. */
-    HardwareDumpUtils::close_breaker(file, prefix);
+    DumpUtils::close_breaker(file, prefix);
     fflush(file);
 }

--- a/Source/Common/HardwareModel/HardwareIterator.h
+++ b/Source/Common/HardwareModel/HardwareIterator.h
@@ -22,7 +22,7 @@
  *   no sense (and is unrealistic) if patches of the hardware are empty.
  */
 
-#include "HardwareDumpUtils.h"
+#include "DumpUtils.h"
 #include "HardwareModel.h"
 #include "IteratorException.h"
 #include "pdigraph.hpp"

--- a/Source/Common/HardwareModel/P_board.cpp
+++ b/Source/Common/HardwareModel/P_board.cpp
@@ -187,13 +187,13 @@ void P_board::connect(AddressComponent start, AddressComponent end,
 void P_board::Dump(FILE* file)
 {
     std::string prefix = dformat("P_board %s", FullName().c_str());
-    HardwareDumpUtils::open_breaker(file, prefix);
+    DumpUtils::open_breaker(file, prefix);
 
     /* About this object and its parent, if any. */
     NameBase::Dump(file);
 
     /* About the mailbox graph. */
-    HardwareDumpUtils::open_breaker(file, "Mailbox connectivity");
+    DumpUtils::open_breaker(file, "Mailbox connectivity");
     if (G.SizeNodes() == 0)
         fprintf(file, "The mailbox graph is empty.\n");
     else
@@ -215,12 +215,12 @@ void P_board::Dump(FILE* file)
         P_link::dfp = previousLinkChannel;
         P_port::dfp = previousPortChannel;
     }
-    HardwareDumpUtils::close_breaker(file, "Mailbox connectivity");
+    DumpUtils::close_breaker(file, "Mailbox connectivity");
 
     /* About contained items, if any. */
     if (G.SizeNodes() > 0)
     {
-        HardwareDumpUtils::open_breaker(file, "Mailboxes in this board");
+        DumpUtils::open_breaker(file, "Mailboxes in this board");
 
         /* Set up callbacks for walking through the mailbox nodes, passing in
          * the file pointer. */
@@ -235,11 +235,11 @@ void P_board::Dump(FILE* file)
         /* Dump mailboxes in the graph recursively. */
         G.WALKNODES(file, WalkCallbacks::node);
 
-        HardwareDumpUtils::close_breaker(file, "Mailboxes in this board");
+        DumpUtils::close_breaker(file, "Mailboxes in this board");
     }
 
     /* Close breaker and flush the dump. */
-    HardwareDumpUtils::close_breaker(file, prefix);
+    DumpUtils::close_breaker(file, prefix);
     fflush(file);
 }
 

--- a/Source/Common/HardwareModel/P_board.h
+++ b/Source/Common/HardwareModel/P_board.h
@@ -13,7 +13,7 @@
 #include <sstream>
 
 #include "AddressableItem.h"
-#include "HardwareDumpUtils.h"
+#include "DumpUtils.h"
 #include "NameBase.h"
 #include "OwnershipException.h"
 #include "P_box.h"

--- a/Source/Common/HardwareModel/P_box.cpp
+++ b/Source/Common/HardwareModel/P_box.cpp
@@ -76,13 +76,13 @@ void P_box::contain(AddressComponent addressComponent, P_board* board)
 void P_box::Dump(FILE* file)
 {
     std::string prefix = dformat("P_box %s", FullName().c_str());
-    HardwareDumpUtils::open_breaker(file, prefix);
+    DumpUtils::open_breaker(file, prefix);
 
     /* About this object and its parent, if any. */
     NameBase::Dump(file);
 
     /* About contained items, if any. */
-    HardwareDumpUtils::open_breaker(file, "Boards in this box");
+    DumpUtils::open_breaker(file, "Boards in this box");
     if (P_boardv.empty()){fprintf(file, "The board vector is empty.\n");}
     else
     {
@@ -92,10 +92,10 @@ void P_box::Dump(FILE* file)
             (*iterator)->Dump(file);
         }
     }
-    HardwareDumpUtils::close_breaker(file, "Boards in this box");
+    DumpUtils::close_breaker(file, "Boards in this box");
 
     /* Close breaker and flush the dump. */
-    HardwareDumpUtils::close_breaker(file, prefix);
+    DumpUtils::close_breaker(file, prefix);
     fflush(file);
 }
 

--- a/Source/Common/HardwareModel/P_box.h
+++ b/Source/Common/HardwareModel/P_box.h
@@ -12,8 +12,8 @@
 #include <sstream>
 
 #include "AddressableItem.h"
+#include "DumpUtils.h"
 #include "NameBase.h"
-#include "HardwareDumpUtils.h"
 #include "OwnershipException.h"
 #include "P_board.h"
 #include "P_engine.h"

--- a/Source/Common/HardwareModel/P_core.cpp
+++ b/Source/Common/HardwareModel/P_core.cpp
@@ -88,7 +88,7 @@ void P_core::contain(AddressComponent addressComponent, P_thread* thread)
 void P_core::Dump(FILE* file)
 {
     std::string prefix = dformat("P_core %s", FullName().c_str());
-    HardwareDumpUtils::open_breaker(file, prefix);
+    DumpUtils::open_breaker(file, prefix);
 
     /* About this object and its parent, if any. */
     NameBase::Dump(file);
@@ -115,7 +115,7 @@ void P_core::Dump(FILE* file)
     }
 
     /* About contained items, if any. */
-    HardwareDumpUtils::open_breaker(file, "Threads in this core");
+    DumpUtils::open_breaker(file, "Threads in this core");
     if (P_threadm.empty())
         fprintf(file, "The thread map is empty.\n");
     else
@@ -126,10 +126,10 @@ void P_core::Dump(FILE* file)
             iterator->second->Dump(file);
         }
     }
-    HardwareDumpUtils::close_breaker(file, "Threads in this core");
+    DumpUtils::close_breaker(file, "Threads in this core");
 
     /* Close breaker and flush the dump. */
-    HardwareDumpUtils::close_breaker(file, prefix);
+    DumpUtils::close_breaker(file, prefix);
     fflush(file);
 }
 

--- a/Source/Common/HardwareModel/P_core.h
+++ b/Source/Common/HardwareModel/P_core.h
@@ -14,7 +14,7 @@
 
 #include "AddressableItem.h"
 #include "Bin.h"
-#include "HardwareDumpUtils.h"
+#include "DumpUtils.h"
 #include "NameBase.h"
 #include "OwnershipException.h"
 #include "P_mailbox.h"

--- a/Source/Common/HardwareModel/P_engine.cpp
+++ b/Source/Common/HardwareModel/P_engine.cpp
@@ -225,7 +225,7 @@ void P_engine::connect(AddressComponent start, AddressComponent end,
 void P_engine::Dump(FILE* file)
 {
     std::string prefix = dformat("P_engine %s", FullName().c_str());
-    HardwareDumpUtils::open_breaker(file, prefix);
+    DumpUtils::open_breaker(file, prefix);
 
     /* About this object. */
     NameBase::Dump(file);
@@ -250,7 +250,7 @@ void P_engine::Dump(FILE* file)
     }
 
     /* About the board graph. */
-    HardwareDumpUtils::open_breaker(file, "Board connectivity");
+    DumpUtils::open_breaker(file, "Board connectivity");
     if (G.SizeNodes() == 0)
         fprintf(file, "The board graph is empty.\n");
     else
@@ -272,10 +272,10 @@ void P_engine::Dump(FILE* file)
         P_link::dfp = previousLinkChannel;
         P_port::dfp = previousPortChannel;
     }
-    HardwareDumpUtils::close_breaker(file, "Board connectivity");
+    DumpUtils::close_breaker(file, "Board connectivity");
 
     /* About contained boxes, if any. */
-    HardwareDumpUtils::open_breaker(file, "Boxes in this engine");
+    DumpUtils::open_breaker(file, "Boxes in this engine");
     if (P_boxm.empty())
         fprintf(file, "The box map is empty.\n");
     else
@@ -286,10 +286,10 @@ void P_engine::Dump(FILE* file)
             iterator->second->Dump(file);
         }
     }
-    HardwareDumpUtils::close_breaker(file, "Boxes in this engine");
+    DumpUtils::close_breaker(file, "Boxes in this engine");
 
     /* Close breaker and flush the dump. */
-    HardwareDumpUtils::close_breaker(file, prefix);
+    DumpUtils::close_breaker(file, prefix);
     fflush(file);
 }
 

--- a/Source/Common/HardwareModel/P_engine.h
+++ b/Source/Common/HardwareModel/P_engine.h
@@ -12,8 +12,8 @@
 
 #include <sstream>
 
+#include "DumpUtils.h"
 #include "HardwareAddress.h"
-#include "HardwareDumpUtils.h"
 #include "NameBase.h"
 #include "OrchBase.h"
 #include "OwnershipException.h"

--- a/Source/Common/HardwareModel/P_link.cpp
+++ b/Source/Common/HardwareModel/P_link.cpp
@@ -20,9 +20,9 @@ void P_link::Dump(FILE* file)
 {
     /* Pretty breaker */
     std::string prefix = dformat("P_link %s", FullName().c_str());
-    HardwareDumpUtils::open_breaker(file, prefix);
+    DumpUtils::open_breaker(file, prefix);
     fprintf(file, "Edge weight: %f\n", weight);
     NameBase::Dump(file);
-    HardwareDumpUtils::close_breaker(file, prefix);
+    DumpUtils::close_breaker(file, prefix);
     fflush(file);
 }

--- a/Source/Common/HardwareModel/P_link.h
+++ b/Source/Common/HardwareModel/P_link.h
@@ -7,7 +7,7 @@
  * See the hardware model documentation for further information on these
  * links. */
 
-#include "HardwareDumpUtils.h"
+#include "DumpUtils.h"
 #include "NameBase.h"
 #include "pdigraph.hpp"
 

--- a/Source/Common/HardwareModel/P_mailbox.cpp
+++ b/Source/Common/HardwareModel/P_mailbox.cpp
@@ -77,13 +77,13 @@ void P_mailbox::contain(AddressComponent addressComponent, P_core* core)
 void P_mailbox::Dump(FILE* file)
 {
     std::string prefix = dformat("P_mailbox %s", FullName().c_str());
-    HardwareDumpUtils::open_breaker(file, prefix);
+    DumpUtils::open_breaker(file, prefix);
 
     /* About this object and its parent, if any. */
     NameBase::Dump(file);
 
     /* About contained items, if any. */
-    HardwareDumpUtils::open_breaker(file, "Cores in this mailbox");
+    DumpUtils::open_breaker(file, "Cores in this mailbox");
     if (P_corem.empty())
         fprintf(file, "The core map is empty.\n");
     else
@@ -94,10 +94,10 @@ void P_mailbox::Dump(FILE* file)
             iterator->second->Dump(file);
         }
     }
-    HardwareDumpUtils::close_breaker(file, "Cores in this mailbox");
+    DumpUtils::close_breaker(file, "Cores in this mailbox");
 
     /* Close breaker and flush the dump. */
-    HardwareDumpUtils::close_breaker(file, prefix);
+    DumpUtils::close_breaker(file, prefix);
     fflush(file);
 }
 

--- a/Source/Common/HardwareModel/P_mailbox.h
+++ b/Source/Common/HardwareModel/P_mailbox.h
@@ -13,7 +13,7 @@
 #include <sstream>
 
 #include "AddressableItem.h"
-#include "HardwareDumpUtils.h"
+#include "DumpUtils.h"
 #include "NameBase.h"
 #include "OwnershipException.h"
 #include "P_board.h"

--- a/Source/Common/HardwareModel/P_port.cpp
+++ b/Source/Common/HardwareModel/P_port.cpp
@@ -12,8 +12,8 @@ P_port::P_port(NameBase* parent)
 void P_port::Dump(FILE* file)
 {
     std::string prefix = dformat("P_port %s", FullName().c_str());
-    HardwareDumpUtils::open_breaker(file, prefix);
+    DumpUtils::open_breaker(file, prefix);
     NameBase::Dump(file);
-    HardwareDumpUtils::close_breaker(file, prefix);
+    DumpUtils::close_breaker(file, prefix);
     fflush(file);
 }

--- a/Source/Common/HardwareModel/P_port.h
+++ b/Source/Common/HardwareModel/P_port.h
@@ -7,7 +7,7 @@
  * See the hardware model documentation for further information on ports, and
  * for what they may be used for in future. */
 
-#include "HardwareDumpUtils.h"
+#include "DumpUtils.h"
 #include "NameBase.h"
 #include "pdigraph.hpp"
 

--- a/Source/Common/HardwareModel/P_thread.cpp
+++ b/Source/Common/HardwareModel/P_thread.cpp
@@ -18,13 +18,13 @@ P_thread::P_thread(std::string name)
 void P_thread::Dump(FILE* file)
 {
     std::string prefix = dformat("P_thread %s", FullName().c_str());
-    HardwareDumpUtils::open_breaker(file, prefix);
+    DumpUtils::open_breaker(file, prefix);
 
     /* About this object and its parent, if any. */
     NameBase::Dump(file);
 
     /* About devices, if any. */
-    HardwareDumpUtils::open_breaker(file, "Devices in this thread");
+    DumpUtils::open_breaker(file, "Devices in this thread");
     if (P_devicel.empty())
         fprintf(file, "The device map is empty.\n");
     else
@@ -32,10 +32,10 @@ void P_thread::Dump(FILE* file)
         WALKLIST(P_device*,P_devicel,iterator)
             fprintf(file, "%s\n", (*iterator)->FullName().c_str());
     }
-    HardwareDumpUtils::close_breaker(file, "Devices in this thread");
+    DumpUtils::close_breaker(file, "Devices in this thread");
 
     /* Close breaker and flush the dump. */
-    HardwareDumpUtils::close_breaker(file, prefix);
+    DumpUtils::close_breaker(file, prefix);
     fflush(file);
 }
 

--- a/Source/Common/HardwareModel/P_thread.h
+++ b/Source/Common/HardwareModel/P_thread.h
@@ -13,7 +13,7 @@
 #include <list>
 
 #include "AddressableItem.h"
-#include "HardwareDumpUtils.h"
+#include "DumpUtils.h"
 #include "macros.h"
 #include "NameBase.h"
 #include "P_core.h"

--- a/Source/Common/SoftwareAddress.cpp
+++ b/Source/Common/SoftwareAddress.cpp
@@ -1,0 +1,128 @@
+/* Defines software address behaviour (see the accompanying header for further
+ * information). */
+
+#include "SoftwareAddress.h"
+
+/* Constructs a software address, and fully populates it. Each argument is a
+ * component of the software address. */
+SoftwareAddress::SoftwareAddress(
+    IsMothershipComponent isMothership,
+    IsCncComponent isCnc,
+    TaskComponent task,
+    OpCodeComponent opCode,
+    DeviceComponent device)
+{
+    definitions = 0;
+    raw = 0;
+
+    /* Use the setters to check for validity where appropriate. */
+    set_ismothership(isMothership);
+    set_iscnc(isCnc);
+    set_task(task);
+    set_opcode(opCode);
+    set_device(device);
+}
+
+/* Alternatively, construct a software address without explicitly priming it
+ * with values. */
+SoftwareAddress::SoftwareAddress(){
+    definitions = 0;
+    raw = 0;
+}
+
+/* Getters, which read from raw. The return values for the opCode and deviceId
+ * getters shrink from the MSB to fit into the return type. */
+IsMothershipComponent SoftwareAddress::get_ismothership()
+    {return raw >> ISMOTHERSHIP_SHIFT;}
+/* Here, the bitwise-and clears the isMothership bit, so the output is either 1
+ * or 0. */
+IsCncComponent SoftwareAddress::get_iscnc()
+    {return ((raw >> ISCNC_SHIFT) & 1);}
+/* Here, the bitwise-and clears the isMothership and isCnc bits, so the
+ * output will fit in six bits. */
+TaskComponent SoftwareAddress::get_task()
+    {return (raw >> TASK_SHIFT) & TASK_MAX;}
+OpCodeComponent SoftwareAddress::get_opcode()
+    {return raw >> OPCODE_SHIFT;}
+DeviceComponent SoftwareAddress::get_device(){return raw;}
+
+/* Setters, which set the address component with a value.
+ *
+ * Also updates the "definitions" word. In the task setter, also raises if the
+ * input does not fit within the loaded format. Arguments:
+ *
+ * - value: Value to set. */
+void SoftwareAddress::set_ismothership(IsMothershipComponent value)
+{
+    raw |= (value ? 1 : 0) << ISMOTHERSHIP_SHIFT;
+    set_defined(0);
+}
+
+void SoftwareAddress::set_iscnc(IsCncComponent value)
+{
+    raw |= (value ? 1 : 0) << ISCNC_SHIFT;
+    set_defined(1);
+}
+
+void SoftwareAddress::set_task(TaskComponent value)
+{
+    /* Validate */
+    if (value > TASK_MAX)
+    {
+        throw InvalidAddressException(
+            dformat("[ERROR] Task component value \"%u\" does not fit the "
+                    "software address format. The task component must fit in "
+                    "6-bits, and so must be less than %d.", value, TASK_MAX));
+    }
+
+    /* Set */
+    raw |= value << TASK_SHIFT;
+    set_defined(2);
+}
+
+void SoftwareAddress::set_opcode(OpCodeComponent value)
+{
+    /* Note that there is no validation here for non-cnc addresses to
+     * facilitate out-of-order address definitions. */
+    raw |= value << OPCODE_SHIFT;
+    set_defined(3);
+}
+
+void SoftwareAddress::set_device(DeviceComponent value)
+{
+    raw |= value;
+    set_defined(4);
+}
+
+/* Write debug and diagnostic information using dumpchan. Arguments:
+ *
+ * - file: File to dump to. */
+void SoftwareAddress::Dump(FILE* file)
+{
+    std::string prefix = dformat("Software address at %#018lx",
+                                 (uint64_t) this);
+    DumpUtils::open_breaker(file, prefix);
+
+    /* The raw address. */
+    fprintf(file, "raw: %" SWA_FMT "\n", raw);
+
+    /* The components. */
+    fprintf(file, "isMothership: %s ", get_ismothership() ? "true" : "false");
+    fprintf(file, "%s\n", is_ismothership_defined() ? "" : "(not defined)");
+
+    fprintf(file, "isCnc: %s ", get_iscnc() ? "true" : "false");
+    fprintf(file, "%s\n", is_iscnc_defined() ? "" : "(not defined)");
+
+    fprintf(file, "task: %u ", get_task());
+    fprintf(file, "%s\n", is_task_defined() ? "" : "(not defined)");
+
+    fprintf(file, "opCode: %u ", get_opcode());
+    fprintf(file, "%s\n", is_opcode_defined() ? "" : "(not defined)");
+
+    fprintf(file, "device: %u ", get_device());
+    fprintf(file, "%s\n", is_device_defined() ? "" : "(not defined)");
+
+    /* Close breaker and flush the dump. */
+    DumpUtils::close_breaker(file, prefix);
+    fflush(file);
+}

--- a/Source/Common/SoftwareAddress.cpp
+++ b/Source/Common/SoftwareAddress.cpp
@@ -54,13 +54,27 @@ DeviceComponent SoftwareAddress::get_device(){return raw;}
  * - value: Value to set. */
 void SoftwareAddress::set_ismothership(IsMothershipComponent value)
 {
-    raw |= (value ? 1 : 0) << ISMOTHERSHIP_SHIFT;
+    if (value)
+    {
+        raw |= ISMOTHERSHIP_BIT_MASK;
+    }
+    else
+    {
+        raw &= ~ISMOTHERSHIP_BIT_MASK;
+    }
     set_defined(0);
 }
 
 void SoftwareAddress::set_iscnc(IsCncComponent value)
 {
-    raw |= (value ? 1 : 0) << ISCNC_SHIFT;
+    if (value)
+    {
+        raw |= ISCNC_BIT_MASK;
+    }
+    else
+    {
+        raw &= ~ISCNC_BIT_MASK;
+    }
     set_defined(1);
 }
 
@@ -75,8 +89,8 @@ void SoftwareAddress::set_task(TaskComponent value)
                     "6-bits, and so must be less than %d.", value, TASK_MAX));
     }
 
-    /* Set */
-    raw |= value << TASK_SHIFT;
+    raw &= ~TASK_BIT_MASK; /* Clear */
+    raw |= value << TASK_SHIFT; /* Set */
     set_defined(2);
 }
 
@@ -84,13 +98,15 @@ void SoftwareAddress::set_opcode(OpCodeComponent value)
 {
     /* Note that there is no validation here for non-cnc addresses to
      * facilitate out-of-order address definitions. */
-    raw |= value << OPCODE_SHIFT;
+    raw &= ~OPCODE_BIT_MASK; /* Clear */
+    raw |= value << OPCODE_SHIFT; /* Set */
     set_defined(3);
 }
 
 void SoftwareAddress::set_device(DeviceComponent value)
 {
-    raw |= value;
+    raw &= ~DEVICE_BIT_MASK; /* Clear */
+    raw |= value; /* Set */
     set_defined(4);
 }
 

--- a/Source/Common/SoftwareAddress.h
+++ b/Source/Common/SoftwareAddress.h
@@ -38,7 +38,7 @@
  *
  * - Bits 16 to 31 (device): Identifies the device uniquely given the other
  *   address components. Is identically zero if isCnc and isMothership are both
- *   zero (i.e. if it's a supervisor device).
+ *   one (i.e. if it's a supervisor device).
  *
  * Setters on software address components operate on a complete address,
  * which is sliced when getters are called.

--- a/Source/Common/SoftwareAddress.h
+++ b/Source/Common/SoftwareAddress.h
@@ -65,6 +65,13 @@
 #define TASK_SHIFT 24
 #define OPCODE_SHIFT 16
 
+/* Define masks for each section. The parentheses are important. */
+#define ISMOTHERSHIP_BIT_MASK (1 << ISMOTHERSHIP_SHIFT)
+#define ISCNC_BIT_MASK (1 << ISCNC_SHIFT)
+#define TASK_BIT_MASK (TASK_MAX << TASK_SHIFT)
+#define OPCODE_BIT_MASK (255 << OPCODE_SHIFT)
+#define DEVICE_BIT_MASK (65535)  /* = 2 ^ 16 - 1 */
+
 /* Software address integer representation. */
 typedef uint32_t SoftwareAddressInt;
 

--- a/Source/Common/SoftwareAddress.h
+++ b/Source/Common/SoftwareAddress.h
@@ -1,0 +1,131 @@
+#ifndef __ORCHESTRATOR_SOURCE_COMMON_SOFTWAREADDRESS_H
+#define __ORCHESTRATOR_SOURCE_COMMON_SOFTWAREADDRESS_H
+
+/* Describes software addresses, which apply to devices in the POETS Engine
+ * that have been placed.
+ *
+ * A software address is sufficient to identify a device deployed in the POETS
+ * stack, either to a thread on a Tinsel core, or something else. In addition,
+ * a software address contains information about the type of device, and a
+ * variety of other quantities. Unlike hardware addresses, software address
+ * formats are fixed at compile-time.
+ *
+ * Software addresses are fundamentally 32-bit integers, where (MSB-first):
+ *
+ * - Bit 0 (isMothership): Is 1 if the device is reached through a Mothership,
+ *   and 0 otherwise.
+ *
+ * - Bit 1 (isCnc): Is 1 if the device is a Supervisor device (if isMothership
+ *   is also 1), and 0 otherwise.
+ *
+ *   The combination of these first two bits defines the type of device being
+ *   addressed, according to this table:
+ *
+ *   +------------+-----+-------------------------------+
+ *   |isMothership|isCnc|        Device Category        |
+ *   +------------+-----+-------------------------------+
+ *   | 0          | 0   | Normal device                 |
+ *   | 1          | 0   | External device               |
+ *   | 1          | 1   | Supervisor device             |
+ *   | 0          | 1   | Normal device (OnCtl handler) |
+ *   +------------+-----+-------------------------------+
+ *
+ * - Bits 2 to 7 (task): Identifies the task that the device is associated
+ *   with (particularly relevant for supervisor devices).
+ *
+ * - Bits 8 to 15 (opCode): Identifies an opCode to be passed to OnCtl. Is
+ *   identically zero if isCnc is zero, but may also be zero if isCnc is one.
+ *
+ * - Bits 16 to 31 (device): Identifies the device uniquely given the other
+ *   address components. Is identically zero if isCnc and isMothership are both
+ *   zero (i.e. if it's a supervisor device).
+ *
+ * Setters on software address components operate on a complete address,
+ * which is sliced when getters are called.
+ *
+ * Software addresses also track which of their components have been defined -
+ * developers can query this state calling SoftwareAddress::is_fully_defined().
+ *
+ * Unlike hardware addresses, software addresses are not hierarchical.
+ *
+ * See the software address documentation for further information about
+ * software addresses. */
+
+#include "DumpUtils.h"
+#include "InvalidAddressException.h"
+#include "OSFixes.hpp"
+
+#define TASK_MAX 63  /* Where 63 = 0b111111 is the greatest value to fit in six
+                      * bits. */
+
+/* Define some common shifts that are applied to the member "raw" to obtain
+ * components. */
+#define ISMOTHERSHIP_SHIFT 31
+#define ISCNC_SHIFT 30
+#define TASK_SHIFT 24
+#define OPCODE_SHIFT 16
+
+/* Software address integer representation. */
+typedef uint32_t SoftwareAddressInt;
+
+/* Component representations (for setters and getters, not for storage) */
+typedef bool IsMothershipComponent;
+typedef bool IsCncComponent;
+typedef uint8_t TaskComponent;
+typedef uint8_t OpCodeComponent;
+typedef uint16_t DeviceComponent;
+
+class SoftwareAddress: public DumpChan
+{
+public:
+    SoftwareAddress(IsMothershipComponent isMothership, IsCncComponent isCnc,
+                    TaskComponent task, OpCodeComponent opCode,
+                    DeviceComponent device);
+    SoftwareAddress();
+
+    /* Getters and setters. */
+    IsMothershipComponent get_ismothership();
+    IsCncComponent get_iscnc();
+    TaskComponent get_task();
+    OpCodeComponent get_opcode();
+    DeviceComponent get_device();
+
+    void set_ismothership(IsMothershipComponent value);
+    void set_iscnc(IsCncComponent value);
+    void set_task(TaskComponent value);
+    void set_opcode(OpCodeComponent value);
+    void set_device(DeviceComponent value);
+
+    /* Access */
+    inline SoftwareAddressInt get_software_address(){return raw;}
+    inline SoftwareAddressInt as_uint(){return get_software_address();}
+    void Dump(FILE* = stdout);
+
+    /* Defines whether or not the software address is fully defined. */
+    inline bool is_fully_defined(){return definitions == 31;}  /* 0b11111 */
+    inline bool is_ismothership_defined(){return (definitions & 1) > 0;}
+    inline bool is_iscnc_defined(){return (definitions & 2) > 0;}
+    inline bool is_task_defined(){return (definitions & 4) > 0;}
+    inline bool is_opcode_defined(){return (definitions & 8) > 0;}
+    inline bool is_device_defined(){return (definitions & 16) > 0;}
+
+private:
+    SoftwareAddressInt raw;
+
+    /* Binary word which stores which components of the address have been
+     * defined. Bits are 0 if not defined, and 1 if defined, according to the
+     * map (LSB-first):
+     *
+     * - Bit 0: isMothership
+     * - Bit 1: isCnc
+     * - Bit 2: task
+     * - Bit 3: opCode
+     * - Bit 4: device
+     *
+     * Functionally this acts as an array of booleans, but uses less memory. */
+    uint8_t definitions;
+
+    /* Convenience method for defining bits of definitions. */
+    inline void set_defined(unsigned index){definitions |= (1 << index);};
+};
+#endif

--- a/Source/Common/SoftwareAddress.h
+++ b/Source/Common/SoftwareAddress.h
@@ -72,6 +72,14 @@
 #define OPCODE_BIT_MASK (255 << OPCODE_SHIFT)
 #define DEVICE_BIT_MASK (65535)  /* = 2 ^ 16 - 1 */
 
+/* Define masks for setting the 'definitions' variable. */
+#define SOFTWARE_ADDRESS_FULLY_DEFINED_MASK 31  /* 0b11111 */
+#define ISMOTHERSHIP_DEFINED_MASK 1             /* 0b00001 */
+#define ISCNC_DEFINED_MASK 2                    /* 0b00010 */
+#define TASK_DEFINED_MASK 4                     /* 0b00100 */
+#define OPCODE_DEFINED_MASK 8                   /* 0b01000 */
+#define DEVICE_DEFINED_MASK 16                  /* 0b10000 */
+
 /* Software address integer representation. */
 typedef uint32_t SoftwareAddressInt;
 
@@ -109,12 +117,18 @@ public:
     void Dump(FILE* = stdout);
 
     /* Defines whether or not the software address is fully defined. */
-    inline bool is_fully_defined(){return definitions == 31;}  /* 0b11111 */
-    inline bool is_ismothership_defined(){return (definitions & 1) > 0;}
-    inline bool is_iscnc_defined(){return (definitions & 2) > 0;}
-    inline bool is_task_defined(){return (definitions & 4) > 0;}
-    inline bool is_opcode_defined(){return (definitions & 8) > 0;}
-    inline bool is_device_defined(){return (definitions & 16) > 0;}
+    inline bool is_fully_defined()
+        {return definitions == SOFTWARE_ADDRESS_FULLY_DEFINED_MASK;}
+    inline bool is_ismothership_defined()
+        {return (definitions & ISMOTHERSHIP_DEFINED_MASK) > 0;}
+    inline bool is_iscnc_defined()
+        {return (definitions & ISCNC_DEFINED_MASK) > 0;}
+    inline bool is_task_defined()
+        {return (definitions & TASK_DEFINED_MASK) > 0;}
+    inline bool is_opcode_defined()
+        {return (definitions & OPCODE_DEFINED_MASK) > 0;}
+    inline bool is_device_defined()
+        {return (definitions & DEVICE_DEFINED_MASK) > 0;}
 
 private:
     SoftwareAddressInt raw;

--- a/Tests/TestSoftwareAddress.cpp
+++ b/Tests/TestSoftwareAddress.cpp
@@ -1,0 +1,169 @@
+/* Tests various behaviours of the software addressing mechanism. */
+
+#define CATCH_CONFIG_MAIN
+
+#include "catch.hpp"
+
+#include "SoftwareAddress.h"
+
+TEST_CASE("Addresses can be created empty and undefined")
+{
+    SoftwareAddress address;
+    REQUIRE(address.get_ismothership() == false);
+    REQUIRE(address.get_iscnc() == false);
+    REQUIRE(address.get_task() == 0);
+    REQUIRE(address.get_opcode() == 0);
+    REQUIRE(address.get_device() == 0);
+
+    REQUIRE(!address.is_ismothership_defined());
+    REQUIRE(!address.is_iscnc_defined());
+    REQUIRE(!address.is_task_defined());
+    REQUIRE(!address.is_opcode_defined());
+    REQUIRE(!address.is_device_defined());
+
+    REQUIRE(!address.is_fully_defined());
+}
+
+TEST_CASE("Addresses can be fully populated on construction")
+{
+    /* This type of device is not valid, because external devices must have a
+     * zero opCode, but this is fine for testing. */
+    bool isMothership = true;
+    bool isCnc = false;
+    uint8_t task = 14;
+    uint8_t opCode = 4;
+    uint16_t device = 65535;
+
+    SoftwareAddress address(isMothership, isCnc, task, opCode, device);
+    REQUIRE(address.get_ismothership() == isMothership);
+    REQUIRE(address.get_iscnc() == isCnc);
+    REQUIRE(address.get_task() == task);
+    REQUIRE(address.get_opcode() == opCode);
+    REQUIRE(address.get_device() == device);
+
+    REQUIRE(address.is_ismothership_defined());
+    REQUIRE(address.is_iscnc_defined());
+    REQUIRE(address.is_task_defined());
+    REQUIRE(address.is_opcode_defined());
+    REQUIRE(address.is_device_defined());
+
+    REQUIRE(address.is_fully_defined());
+}
+
+TEST_CASE("Empty addresses are full of zero (or false) components")
+{
+    SoftwareAddress address;
+    REQUIRE(address.get_ismothership() == false);
+    REQUIRE(address.get_iscnc() == false);
+    REQUIRE(address.get_task() == 0);
+    REQUIRE(address.get_opcode() == 0);
+    REQUIRE(address.get_device() == 0);
+}
+
+TEST_CASE("Empty addresses can be populated in stages")
+{
+    /* This is for the OnCtl handler of normal device 102 operating as part
+     * Orchestrator task 1 on the target thread defined by the hardware address
+     * (not included here). It will run the command-and-control operation 255
+     * (used by the OnCtl handler, or not). */
+    bool isMothership = false;
+    bool isCnc = true;
+    uint8_t task = 1;
+    uint8_t opCode = 255;
+    uint16_t device = 102;
+
+    SoftwareAddress address;
+
+    /* Populate with isMothersip and device only */
+    address.set_ismothership(isMothership);
+    address.set_device(device);
+
+    REQUIRE(address.get_ismothership() == isMothership);
+    REQUIRE(address.get_device() == device);
+
+    REQUIRE(address.is_ismothership_defined());
+    REQUIRE(address.is_device_defined());
+
+    /* Nothing else should be defined, and should return zero-ish on being
+     * gotten. */
+    REQUIRE(address.get_iscnc() == false);
+    REQUIRE(address.get_task() == 0);
+    REQUIRE(address.get_opcode() == 0);
+    REQUIRE(!address.is_iscnc_defined());
+    REQUIRE(!address.is_task_defined());
+    REQUIRE(!address.is_opcode_defined());
+
+    REQUIRE(!address.is_fully_defined());
+
+    /* Define the rest of them. */
+    address.set_iscnc(isCnc);
+    address.set_task(task);
+    address.set_opcode(opCode);
+
+    /* Everything should now be defined. */
+    REQUIRE(address.get_ismothership() == isMothership);
+    REQUIRE(address.get_iscnc() == isCnc);
+    REQUIRE(address.get_task() == task);
+    REQUIRE(address.get_opcode() == opCode);
+    REQUIRE(address.get_device() == device);
+
+    REQUIRE(address.is_ismothership_defined());
+    REQUIRE(address.is_iscnc_defined());
+    REQUIRE(address.is_task_defined());
+    REQUIRE(address.is_opcode_defined());
+    REQUIRE(address.is_device_defined());
+
+    REQUIRE(address.is_fully_defined());
+}
+
+TEST_CASE("An invalid task input cannot be set")
+{
+    SoftwareAddress address;
+    /* Can't be > 63. */
+    REQUIRE_THROWS_AS(address.set_task(64), InvalidAddressException&);
+
+    /* Test with 0b11111111, which is also > 63. */
+    REQUIRE_THROWS_AS(address.set_task(-1), InvalidAddressException&);
+}
+
+TEST_CASE("Fully-defined software addresses can be dumped as a 32-bit string")
+{
+    /* This is a supervisor device for Orchestrator task 59. It will run the
+     * command-and-control operation 47 (used by the supervisor handler, or
+     * not). */
+    bool isMothership = true;
+    bool isCnc = true;
+    uint8_t task = 59;
+    uint8_t opCode = 47;
+    uint16_t device = 0;
+
+    SoftwareAddress address(isMothership, isCnc, task, opCode, device);
+    REQUIRE(address.is_fully_defined());
+
+    /* This should be 1 1 11,1011 0010,1111 0000,0000,0000,0000 = 4214161408 */
+    uint32_t expectedResult = 4214161408;
+    REQUIRE(address.as_uint() == expectedResult);
+    REQUIRE(address.get_software_address() == expectedResult);
+}
+
+TEST_CASE("Partially-defined software addresses can also be dumped")
+{
+    /* This is a normal device. Since non-OnCtl packets to normal devices have
+       a zero opcode, we can simply forgo defining it. */
+    bool isMothership = false;
+    bool isCnc = false;
+    uint8_t task = 1;
+    uint16_t device = 0;
+
+    SoftwareAddress address;
+    address.set_ismothership(isMothership);
+    address.set_iscnc(isCnc);
+    address.set_task(task);
+    address.set_device(device);
+    REQUIRE(!address.is_fully_defined());
+
+    /* This should be 0 0 00,0001 0000,0000 0000,0000,0000,0000 = 16777216 */
+    uint32_t expectedResult = 16777216;
+    REQUIRE(address.as_uint() == expectedResult);
+    REQUIRE(address.get_software_address() == expectedResult);
+}

--- a/Tests/TestSoftwareAddress.cpp
+++ b/Tests/TestSoftwareAddress.cpp
@@ -205,3 +205,17 @@ TEST_CASE("Partially-defined software addresses can also be dumped")
     REQUIRE(address.as_uint() == expectedResult);
     REQUIRE(address.get_software_address() == expectedResult);
 }
+
+/*
+// A simple dumping test. The device here is a supervisor device with it's
+// device component unset at 0.
+TEST_CASE("Dump for fun")
+{
+    SoftwareAddress address;
+    address.set_ismothership(true);
+    address.set_iscnc(true);
+    address.set_task(2);
+    address.set_opcode(11);
+    address.Dump();
+}
+ */

--- a/Tests/TestSoftwareAddress.cpp
+++ b/Tests/TestSoftwareAddress.cpp
@@ -116,6 +116,44 @@ TEST_CASE("Empty addresses can be populated in stages")
     REQUIRE(address.is_fully_defined());
 }
 
+TEST_CASE("Address components can be redefined")
+{
+    bool isMothership = true;
+    bool isCnc = false;
+    uint8_t task = 14;
+    uint8_t opCode = 0;
+    uint16_t device = 65535;
+    SoftwareAddress address(isMothership, isCnc, task, opCode, device);
+
+    /* Now we redefine the components. */
+    isMothership = !isMothership;
+    isCnc = !isCnc;
+    task = 17;
+    opCode = 2;
+    device = 0;
+
+    address.set_ismothership(isMothership);
+    address.set_iscnc(isCnc);
+    address.set_task(task);
+    address.set_opcode(opCode);
+    address.set_device(device);
+
+    /* Everything should now be defined according to the second definition. */
+    REQUIRE(address.get_ismothership() == isMothership);
+    REQUIRE(address.get_iscnc() == isCnc);
+    REQUIRE(address.get_task() == task);
+    REQUIRE(address.get_opcode() == opCode);
+    REQUIRE(address.get_device() == device);
+
+    REQUIRE(address.is_ismothership_defined());
+    REQUIRE(address.is_iscnc_defined());
+    REQUIRE(address.is_task_defined());
+    REQUIRE(address.is_opcode_defined());
+    REQUIRE(address.is_device_defined());
+
+    REQUIRE(address.is_fully_defined());
+}
+
 TEST_CASE("An invalid task input cannot be set")
 {
     SoftwareAddress address;


### PR DESCRIPTION
This changeset:

 - Adds a software address class, which can be integrated into various parts of the Orchestrator, and can be used in a definition of a packet header.

 - Adds tests for said software address class

 - Moves the quite useful `Source/HardwareModel/HardwareDumpUtils.{cpp,h}` to `Source/DumpUtils.{cpp,h}`, so that the `SoftwareAddress` logic can use it without feeling guilty.

There is some documentation for software addresses, and the `SoftwareAddress` class, in the `orchestrator-documentation` repository in the `software-address` branch (https://github.com/POETSII/orchestrator-documentation/tree/software-address). I (will email/have emailed) this around, but feel free if you want to try to build it yourself.

Addresses #53 .