### PR TITLE
Orchestrator Tinsel 0.6 Compatibility

### DIFF
--- a/Build/gcc/Makefile
+++ b/Build/gcc/Makefile
@@ -35,10 +35,6 @@ TESTS_DIR := $(ROOT_DIR)/Tests
 # placed in a directory structure that mimics the source directory structure.
 OBJECT_DIR := ./Objects
 
-# We also compile some hostlink sources for the Mothership component of the
-# Orchestrator.
-HOSTLINK_OBJECT_DIR := ./Objects/Hostlink
-
 # Executable binaries are built to here (directory is created as executable
 # binaries are built):
 EXECUTABLE_DIR := $(ROOT_DIR)/bin
@@ -163,7 +159,7 @@ $(MOTHERSHIP_EXECUTABLE):
 	$(CXX) -pthread -Wl,-rpath-link=$(QT_LIB_DIR) \
         -Wl,-export-dynamic \
         -L$(MPICH_LIB_DIR) -L$(QT_LIB_DIR) -L$(JTAG_LIB_DIR) -L/usr/lib \
-        -o $@ $^ \
+        -o $@ $^ $(TINSEL_HOSTLINK_DIR)/*.o \
         -lQt5Core -lmpi -lpthread -ldl \
         -ljtag_atlantic -ljtag_client
 
@@ -178,9 +174,6 @@ define build-object
 endef
 
 $(OBJECT_DIR)/%.o: $(ROOT_DIR)/%.cpp $(DEPENDENCY_DIR)/%.d
-	$(build-object)
-
-$(HOSTLINK_OBJECT_DIR)/%.o: $(TINSEL_HOSTLINK_DIR)/%.cpp $(DEPENDENCY_DIR)/%.d
 	$(build-object)
 
 # Miscellaneous files to be copied to the execution directory in order for
@@ -291,7 +284,7 @@ $(DEPENDENCY_DIR)/%.d:
 
 clean: application_staging_environment_teardown
 	rm --force --recursive $(OBJECT_DIR) $(DEPENDENCY_DIR) $(EXECUTABLE_DIR) \
-	$(HOSTLINK_OBJECT_DIR) $(ORCHESTRATE_SCRIPT) $(TEST_EXECUTABLE_DIR)
+	$(ORCHESTRATE_SCRIPT) $(TEST_EXECUTABLE_DIR)
 
 # Dependency files must not be removed by Make (unless explicitly cleaned).
 .PRECIOUS: $(DEPENDENCY_DIR)/%.d

--- a/Build/gcc/Makefile
+++ b/Build/gcc/Makefile
@@ -108,8 +108,6 @@ LOGSERVER_MESSAGE_FILE = $(EXECUTABLE_DIR)/OrchestratorMessages.txt
 RTCL_EXECUTABLE = $(EXECUTABLE_DIR)/rtcl
 INJECTOR_EXECUTABLE = $(EXECUTABLE_DIR)/injector
 MOTHERSHIP_EXECUTABLE = $(EXECUTABLE_DIR)/mothership
-JTAG_ATLANTIC_LOCAL = $(EXECUTABLE_DIR)/libjtag_atlantic.so
-JTAG_CLIENT_LOCAL = $(EXECUTABLE_DIR)/libjtag_client.so
 
 all: orchestrate root dummy logserver rtcl injector mothership \
      application_staging_environment
@@ -119,8 +117,7 @@ dummy: $(DUMMY_EXECUTABLE)
 logserver: $(LOGSERVER_EXECUTABLE) $(LOGSERVER_MESSAGE_FILE)
 rtcl: $(RTCL_EXECUTABLE)
 injector: $(INJECTOR_EXECUTABLE)
-mothership: $(MOTHERSHIP_EXECUTABLE) \
-            $(JTAG_ATLANTIC_LOCAL) $(JTAG_CLIENT_LOCAL)
+mothership: $(MOTHERSHIP_EXECUTABLE)
 
 # Prerequisites (objects) for building executables are defined here:
 include Makefile.executable_prerequisites
@@ -158,10 +155,9 @@ $(MOTHERSHIP_EXECUTABLE):
 	@$(shell $(MKDIR) $(EXECUTABLE_DIR))
 	$(CXX) -pthread -Wl,-rpath-link=$(QT_LIB_DIR) \
         -Wl,-export-dynamic \
-        -L$(MPICH_LIB_DIR) -L$(QT_LIB_DIR) -L$(JTAG_LIB_DIR) -L/usr/lib \
+        -L$(MPICH_LIB_DIR) -L$(QT_LIB_DIR) -L/usr/lib \
         -o $@ $^ $(TINSEL_HOSTLINK_DIR)/*.o \
-        -lQt5Core -lmpi -lpthread -ldl \
-        -ljtag_atlantic -ljtag_client
+        -lQt5Core -lmpi -lpthread -ldl
 
 # Object generation. Note: The move command installs the assembled dependency
 # file (see *Note 1*). The touch updates the timestamp on the target (to avoid
@@ -176,12 +172,9 @@ endef
 $(OBJECT_DIR)/%.o: $(ROOT_DIR)/%.cpp $(DEPENDENCY_DIR)/%.d
 	$(build-object)
 
-# Miscellaneous files to be copied to the execution directory in order for
-# various components of the Orchestrator to function.
+# Files to be copied to the execution directory in order for various components
+# of the Orchestrator to function.
 $(LOGSERVER_MESSAGE_FILE): $(LOGSERVER_MESSAGE_FILE_ORIGIN)
-$(JTAG_ATLANTIC_LOCAL): $(JTAG_LIB_DIR)/libjtag_atlantic.so
-$(JTAG_CLIENT_LOCAL): $(JTAG_LIB_DIR)/libjtag_client.so
-$(LOGSERVER_MESSAGE_FILE) $(JTAG_ATLANTIC_LOCAL) $(JTAG_CLIENT_LOCAL):
 	@$(MKDIR) $$(dirname $@)
 	cp "$<" "$@"
 
@@ -202,7 +195,6 @@ $(ORCHESTRATE_SCRIPT): $(ORCHESTRATE_TEMPLATE)
         ["MPICH_DIR"]="$(realpath $(MPICH_DIR))" \
 		["MPICH_LIB_DIR"]="$(realpath $(MPICH_LIB_DIR))" \
 		["QT_LIB_DIR"]="$(realpath $(QT_LIB_DIR))" \
-		["JTAG_LIB_DIR"]="$(realpath $(JTAG_LIB_DIR))" \
 		["GCC_LIB_DIR"]="$(realpath $(GCC_LIB_DIR))" \
 		["CR_LIB_DIR"]="$(realpath $(CR_LIB_DIR))" \
 		["RISCV_DIR"]="$(realpath $(RISCV_DIR))" \

--- a/Build/gcc/Makefile.dependencies
+++ b/Build/gcc/Makefile.dependencies
@@ -7,7 +7,7 @@
 # where you have extracted it to.
 #
 # In Mark's case, it looks like this:
-ORCHESTRATOR_DEPENDENCIES_DIR ?= /local/orchestrator-common/orchestrator_dependencies-5
+ORCHESTRATOR_DEPENDENCIES_DIR ?= /home/mv1g18/orchestrator_dependencies-5
 
 # If you're using the "orchestrator_dependencies" tarball, you shouldn't need
 # to do anything more. If you aren't, you'll need to configure the following to

--- a/Build/gcc/Makefile.dependencies
+++ b/Build/gcc/Makefile.dependencies
@@ -7,7 +7,7 @@
 # where you have extracted it to.
 #
 # In Mark's case, it looks like this:
-ORCHESTRATOR_DEPENDENCIES_DIR ?= /home/mv1g18/orchestrator_dependencies-5
+ORCHESTRATOR_DEPENDENCIES_DIR ?= /local/orchestrator-common/orchestrator_dependencies-5
 
 # If you're using the "orchestrator_dependencies" tarball, you shouldn't need
 # to do anything more. If you aren't, you'll need to configure the following to

--- a/Build/gcc/Makefile.dependencies
+++ b/Build/gcc/Makefile.dependencies
@@ -27,9 +27,6 @@ QT_DIR = $(ORCHESTRATOR_DEPENDENCIES_DIR)/Qt5.6.3/5.6.3/gcc_64
 QT_LIB_DIR = $(QT_DIR)/lib
 QT_INC_DIR = $(QT_DIR)/include
 
-# jtag library paths
-JTAG_LIB_DIR = $(ORCHESTRATOR_DEPENDENCIES_DIR)/jtag_libs
-
 # Tinsel (must be out of date, for now)
 TINSEL_DIR = $(ORCHESTRATOR_DEPENDENCIES_DIR)/tinsel
 TINSEL_INC_DIR = $(TINSEL_DIR)/include

--- a/Build/gcc/Makefile.executable_prerequisites
+++ b/Build/gcc/Makefile.executable_prerequisites
@@ -197,9 +197,7 @@ INJECTOR_SOURCES += $(TRULY_COMMON_SOURCES)
 #
 # - A set of base Orchestrator (/Source/OrchBase) sources.
 #
-# - Parts of the HostLink, taken from the tinsel set of software
-#   dependencies (these are bound to a different variable).
-#
+# Hostlink sources are to be compiled separately.
 MOTHERSHIP_SOURCES = $(SOURCE_DIR)/Mothership/MothershipMain.cpp \
                      $(SOURCE_DIR)/Mothership/TaskInfo.cpp \
                      $(SOURCE_DIR)/Mothership/TMoth.cpp \
@@ -220,12 +218,6 @@ MOTHERSHIP_SOURCES = $(SOURCE_DIR)/Mothership/MothershipMain.cpp \
                      $(HARDWARE_DEPLOYER_SOURCES)
 
 MOTHERSHIP_SOURCES += $(TRULY_COMMON_SOURCES)
-
-HOSTLINK_SOURCES = $(TINSEL_HOSTLINK_DIR)/DebugLink.cpp \
-                   $(TINSEL_HOSTLINK_DIR)/HostLink.cpp \
-                   $(TINSEL_HOSTLINK_DIR)/MemFileReader.cpp \
-                   $(TINSEL_HOSTLINK_DIR)/PowerLink.cpp \
-                   $(TINSEL_HOSTLINK_DIR)/UART.cpp \
 
 # Convert these lists of sources into a list of objects to define a dependency
 # system for the linker.
@@ -253,9 +245,6 @@ orch_sources_to_objects = $(call sources_to_objects, $(ROOT_DIR),\
 
 # Define object lists. OBJECT_TEMPLATE defines the substitutions made in the
 # foreach loop below.
-#
-# Hostlink objects are defined separately, because the substitution is
-# different.
 define OBJECT_TEMPLATE
 $(1)_OBJECTS := $(call orch_sources_to_objects, $($(1)_SOURCES))
 endef
@@ -263,10 +252,6 @@ endef
 $(foreach object_set,\
           ROOT INJECTOR DUMMY LOGSERVER RTCL MOTHERSHIP,\
           $(eval $(call OBJECT_TEMPLATE,$(object_set))))
-
-HOSTLINK_OBJECTS := $(call sources_to_objects, $(TINSEL_HOSTLINK_DIR),\
-                                               $(HOSTLINK_OBJECT_DIR),\
-                                               $(HOSTLINK_SOURCES))
 
 # Define executable prerequisites. RULE_TEMPLATE defines the substitutions made
 # in the foreach loop below.
@@ -278,7 +263,5 @@ $($(1)_EXECUTABLE): $($(1)_OBJECTS)
 endef
 
 $(foreach executable_name,\
-          ROOT DUMMY LOGSERVER RTCL INJECTOR,\
+          ROOT DUMMY LOGSERVER RTCL INJECTOR MOTHERSHIP,\
           $(eval $(call RULE_TEMPLATE,$(executable_name))))
-
-$(MOTHERSHIP_EXECUTABLE): $(MOTHERSHIP_OBJECTS) $(HOSTLINK_OBJECTS)

--- a/Build/gcc/Resources/orchestrate_template.sh
+++ b/Build/gcc/Resources/orchestrate_template.sh
@@ -88,11 +88,9 @@ fi
 # Paths for dynamically-linked libraries.
 MPI_LIB_DIR="{{ MPICH_LIB_DIR }}"
 QT_LIB_DIR="{{ QT_LIB_DIR }}"
-JTAG_LIB_DIR="{{ JTAG_LIB_DIR }}"
 GCC_LIB_DIR="{{ GCC_LIB_DIR }}"
 CR_LIB_DIR="{{ CR_LIB_DIR }}"
-INTERNAL_LIB_PATH=./:"$QT_LIB_DIR":"$MPI_LIB_DIR":\
-"$GCC_LIB_DIR":"$JTAG_LIB_DIR":
+INTERNAL_LIB_PATH=./:"$QT_LIB_DIR":"$MPI_LIB_DIR":"$GCC_LIB_DIR":
 
 # Paths for dynamically-linked libraries required by MPI.
 export LD_LIBRARY_PATH="$CR_LIB_DIR":"$LD_LIBRARY_PATH":./

--- a/Source/Mothership/TMoth.cpp
+++ b/Source/Mothership/TMoth.cpp
@@ -325,7 +325,7 @@ unsigned TMoth::CmRun(string task)
      barrier_msg.destDeviceAddr = DEST_BROADCAST; // send to every device on the thread with a supervisor message
      DebugPrint("Attempting to send barrier release message to the thread "
                 "with hardware address %u.\n", *R);
-     trySend(*R,(p_hdr_size()/(4 << TinselLogWordsPerFlit) + (p_hdr_size()%(4 << TinselLogWordsPerFlit) ? 1 : 0)), &barrier_msg);
+     while(!trySend(*R,(p_hdr_size()/(4 << TinselLogWordsPerFlit) + (p_hdr_size()%(4 << TinselLogWordsPerFlit) ? 1 : 0)), &barrier_msg));
    }
    DebugPrint("Tinsel threads now on their own for task %s\n",task.c_str());
    TaskMap[task]->status = TaskInfo_t::TASK_RUN;
@@ -389,7 +389,7 @@ unsigned TMoth::CmStop(string task)
      DebugPrint("Stopping thread %d in task %s\n", destDevAddr, task.c_str());
      stop_msg.destDeviceAddr = DEST_BROADCAST; // issue the stop message to all devices
      // then issue the stop packet
-     trySend(destDevAddr,(p_hdr_size()/(4 << TinselLogWordsPerFlit) + p_hdr_size()%(4 << TinselLogWordsPerFlit) ? 1 : 0),&stop_msg);
+     while(!trySend(destDevAddr,(p_hdr_size()/(4 << TinselLogWordsPerFlit) + p_hdr_size()%(4 << TinselLogWordsPerFlit) ? 1 : 0),&stop_msg));
    }
    TaskMap[task]->status = TaskInfo_t::TASK_END;
    // check to see if there are any other active tasks
@@ -856,7 +856,7 @@ WALKVECTOR(P_Msg_t, msgs, msg) // and they're sent blindly
    uint32_t FlitLen = Len >> TinselLogBytesPerFlit;
    if (Len << (32-TinselLogBytesPerFlit)) ++FlitLen;
    // if we have to we can run OnIdle to empty receive buffers
-   trySend(msg->header.destDeviceAddr, FlitLen, &(*msg));
+   while(!trySend(msg->header.destDeviceAddr, FlitLen, &(*msg)));
 }
 return 0;
 }

--- a/Source/Mothership/TMoth.cpp
+++ b/Source/Mothership/TMoth.cpp
@@ -325,7 +325,7 @@ unsigned TMoth::CmRun(string task)
      barrier_msg.destDeviceAddr = DEST_BROADCAST; // send to every device on the thread with a supervisor message
      DebugPrint("Attempting to send barrier release message to the thread "
                 "with hardware address %u.\n", *R);
-     while(!trySend(*R,(p_hdr_size()/(4 << TinselLogWordsPerFlit) + (p_hdr_size()%(4 << TinselLogWordsPerFlit) ? 1 : 0)), &barrier_msg));
+     send(*R,(p_hdr_size()/(4 << TinselLogWordsPerFlit) + (p_hdr_size()%(4 << TinselLogWordsPerFlit) ? 1 : 0)), &barrier_msg, true);
    }
    DebugPrint("Tinsel threads now on their own for task %s\n",task.c_str());
    TaskMap[task]->status = TaskInfo_t::TASK_RUN;
@@ -389,7 +389,7 @@ unsigned TMoth::CmStop(string task)
      DebugPrint("Stopping thread %d in task %s\n", destDevAddr, task.c_str());
      stop_msg.destDeviceAddr = DEST_BROADCAST; // issue the stop message to all devices
      // then issue the stop packet
-     while(!trySend(destDevAddr,(p_hdr_size()/(4 << TinselLogWordsPerFlit) + p_hdr_size()%(4 << TinselLogWordsPerFlit) ? 1 : 0),&stop_msg));
+     send(destDevAddr,(p_hdr_size()/(4 << TinselLogWordsPerFlit) + p_hdr_size()%(4 << TinselLogWordsPerFlit) ? 1 : 0), &stop_msg, true);
    }
    TaskMap[task]->status = TaskInfo_t::TASK_END;
    // check to see if there are any other active tasks
@@ -856,7 +856,7 @@ WALKVECTOR(P_Msg_t, msgs, msg) // and they're sent blindly
    uint32_t FlitLen = Len >> TinselLogBytesPerFlit;
    if (Len << (32-TinselLogBytesPerFlit)) ++FlitLen;
    // if we have to we can run OnIdle to empty receive buffers
-   while(!trySend(msg->header.destDeviceAddr, FlitLen, &(*msg)));
+   send(msg->header.destDeviceAddr, FlitLen, &(*msg), true);
 }
 return 0;
 }


### PR DESCRIPTION
This changeset modifies the Orchestrator to operate under Tinsel 0.6 with the appropriate Orchestrator dependencies tarball (see the orchestrator-dependencies repo). Specifically, it:

 - Removes the build of HostLink sources as part of the Mothership. See 4819878c.

 - Replaces the deprecated `HostLink::canSend`, then `HostLink::send` pattern with `HostLink::trySend`, which logically combines these operations. Worth noting that this breaks compatibility with earlier Tinsel versions. See 78a0bd39.

This changeset was tested under Tinsel `0dbbc92`, as 0.6.1 is still a bit of a moving target. It was tested by running @heliosfa 's 40x40 heated plate, which spat out these files (`plate_40x40_out.txt` was `plate_40x40_out.csv`, but I renamed it because GitHub doesn't play nice):

 - [plate_40x40_time.txt](https://github.com/POETSII/Orchestrator/files/3227290/plate_40x40_time.txt)

 - [plate_40x40_out.txt](https://github.com/POETSII/Orchestrator/files/3227294/plate_40x40_out.txt)

@heliosfa and @AlexRast , I recommend testing this before confirming with @mn416 that it works for us all, unless you are happy with Coleridge and Defoe disappearing from under you.
