### PR TITLE
Check before clobbering items in the hardware stack.

### DIFF
--- a/Source/Common/HardwareModel/P_board.cpp
+++ b/Source/Common/HardwareModel/P_board.cpp
@@ -127,9 +127,18 @@ void P_board::contain(AddressComponent addressComponent, P_mailbox* mailbox)
         throw OwnershipException(errorMessage.str());
     }
 
-    /* We don't care about the result of inserting the mailbox into this graph,
-     * because we've checked the item is not owned before adding it. */
-    G.InsertNode(addressComponent, mailbox);
+    /* Verify that there is no address clash. The operation in the predicate
+     * performs the containment. */
+    if (!G.InsertNode(addressComponent, mailbox))
+    {
+        std::stringstream errorMessage;
+        errorMessage << "Mailbox \"" << mailbox->Name()
+            << "\" is already present in the graph held by this board ("
+            << Name()
+            << "). The mailbox's full name is \"" << mailbox->FullName()
+            << "\".";
+        throw OwnershipException(errorMessage.str());
+    }
 
     /* Define a hardware address for the mailbox, if we have a hardware
      * address. */

--- a/Source/Common/HardwareModel/P_engine.cpp
+++ b/Source/Common/HardwareModel/P_engine.cpp
@@ -135,6 +135,20 @@ void P_engine::contain(AddressComponent addressComponent, P_box* box)
         throw OwnershipException(errorMessage.str());
     }
 
+    /* Verify that a box with that address doesn't already exist, to avoid
+     * clobbering. */
+    std::map<AddressComponent, P_box*>::iterator boxFinder;
+    boxFinder = P_boxm.find(addressComponent);
+    if (boxFinder != P_boxm.end())
+    {
+        std::stringstream errorMessage;
+        errorMessage << "Cannot add box \"" << box->Name()
+                     << "\" with address component \"" << addressComponent
+                     << "\" because box \"" << boxFinder->second->Name()
+                     << "\" already exists at that address component.";
+        throw OwnershipException(errorMessage.str());
+    }
+
     P_boxm[addressComponent] = box;
 
     /* Define a hardware address for the box. */


### PR DESCRIPTION
Caused by adding child items with the same address to the same parent item. Also added some tests to ensure the stack throws to OrchBase if we are about to clobber something.