### PR TITLE
Fix format security warnings in the hardware model on 7.x.x.

### DIFF
--- a/Source/Common/HardwareModel/P_board.cpp
+++ b/Source/Common/HardwareModel/P_board.cpp
@@ -20,7 +20,7 @@ P_board::P_board(std::string name)
         }
         GRAPH_CALLBACK node(P_mailbox* const& mailbox)
         {
-            fprintf(mailbox->dfp, mailbox->FullName().c_str());
+            fprintf(mailbox->dfp, "%s", mailbox->FullName().c_str());
         }
         GRAPH_CALLBACK arc(P_link* const& link)
         {

--- a/Source/Common/HardwareModel/P_engine.cpp
+++ b/Source/Common/HardwareModel/P_engine.cpp
@@ -23,7 +23,7 @@ P_engine::P_engine(std::string name)
         }
         GRAPH_CALLBACK node(P_board* const& board)
         {
-            fprintf(board->dfp, board->FullName().c_str());
+            fprintf(board->dfp, "%s", board->FullName().c_str());
         }
         GRAPH_CALLBACK arc(P_link* const& link)
         {


### PR DESCRIPTION
Removes two warnings when compiling the hardware model. These warnings arise because GCC wants to introspect the `format` (second) argument of `int fprintf(FILE* stream, const char* format, ...)` but can't, because it cannot be determined at compile time. This change makes the format specifier explicit wherever this pattern is used in the hardware model.

Resolves #66 .