### PR TITLE
Better C++98 compatibility

### DIFF
--- a/Generics/pdigraph.hpp
+++ b/Generics/pdigraph.hpp
@@ -3,6 +3,7 @@
 
 #include "rand.h"
 #include <map>
+#include <string>
 #include <vector>
 #include <utility>
 using namespace std;

--- a/Generics/pdigraph.tpp
+++ b/Generics/pdigraph.tpp
@@ -181,7 +181,7 @@ return true;
 
 PDIGRAPH_ void _PDIGRAPH::Dump()
 {
-string s(35,'=');
+std::string s(35,'=');
 fprintf(dfp,"Pdigraph topological dump %35s++++++++++++++++++++\n",s.c_str());
 fprintf(dfp,"Node index (%u entries):\n",static_cast<unsigned>(index_n.size()));
 int c1 = 1;

--- a/Source/Common/CommonBase.h
+++ b/Source/Common/CommonBase.h
@@ -51,8 +51,6 @@ void                   SendPMap(MPI_Comm,PMsg_p*);
 int                    RootCIdx();
 void                   MPISpinner();
 
-const int              MPICli = 0;
-
 public:
 vector<FnMap_t*>       FnMapx;
 vector<MPI_Comm>       Comms;    // this could be a map indexed by service name
@@ -83,8 +81,7 @@ MPI_Comm               Tcomm;       // New comm set up by an MPI_Comm_accept
 private:
 char *                 MPI_Buf;
 int                    Msgbufsz;
-const int              LOG_MSGBUF_BLK_SZ = 14;
-const int              MSGBUF_BLK_MASK = (1<<LOG_MSGBUF_BLK_SZ)-1;
+static const int       LOG_MSGBUF_BLK_SZ = 14;
 
 };
 

--- a/Source/Common/HardwareModel/HardwareIterator.cpp
+++ b/Source/Common/HardwareModel/HardwareIterator.cpp
@@ -285,7 +285,11 @@ void HardwareIterator::Dump(FILE* file)
     /* Print whether or not each iterator has changed since the last time it
      * was polled. */
     std::vector<std::string> itemTypes;
-    itemTypes.insert(itemTypes.end(), {"board", "mailbox", "core", "thread"});
+    itemTypes.push_back("board");
+    itemTypes.push_back("mailbox");
+    itemTypes.push_back("core");
+    itemTypes.push_back("thread");
+
     for (long unsigned typeIndex = 0; typeIndex < itemTypes.size();
          typeIndex++)
     {

--- a/Source/OrchBase/Constraints.h
+++ b/Source/OrchBase/Constraints.h
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include "NameBase.h"
+#include "OSFixes.hpp"
 
 //==============================================================================
 

--- a/Source/OrchBase/HardwareFileManager/HardwareFileNotLoadedException.h
+++ b/Source/OrchBase/HardwareFileManager/HardwareFileNotLoadedException.h
@@ -9,9 +9,9 @@
 class HardwareFileNotLoadedException: public HardwareFileParserException
 {
 public:
-    HardwareFileNotLoadedException():HardwareFileParserException{""}
-    {message = "[ERROR] Engine-population attempted without first "
-               "loading a file.\n";}
+    HardwareFileNotLoadedException():
+        HardwareFileParserException("[ERROR] Engine-population attempted "
+                                    "without first loading a file.\n"){};
 };
 
 #endif

--- a/Source/OrchBase/P_builder.cpp
+++ b/Source/OrchBase/P_builder.cpp
@@ -1312,7 +1312,7 @@ unsigned P_builder::WriteThreadVars(string& task_dir, unsigned coreNum,
     if (inTypCnt)
     {
       std::string thrDevNameIn = "Thread_";
-      thrDevNameIn += std::to_string(thread_num) + std::string("_Device_");
+      thrDevNameIn += TO_STRING(thread_num) + std::string("_Device_");
       thrDevNameIn += (*device)->Name() + std::string("_InputPins");
       
       vars_h << "//----------------------- Input Pin (Associative) Tables ";

--- a/Source/OrchBase/P_builder.cpp
+++ b/Source/OrchBase/P_builder.cpp
@@ -305,9 +305,9 @@ unsigned P_builder::GenFiles(P_task* task)
           std::stringstream vars_hFName;
           vars_hFName << task_dir << GENERATED_H_PATH;
           vars_hFName << "/vars_" << coreNum << ".h";
-          std::ofstream vars_h(vars_hFName.str());              // variables header
-          
-          
+          std::ofstream vars_h(vars_hFName.str().c_str());  // variables header
+
+
           //====================================================================
           
           
@@ -403,8 +403,9 @@ unsigned P_builder::GenSupervisor(P_task* task)
     //==========================================================================
     std::stringstream supervisor_hFName;
     supervisor_hFName << task_dir << "/" << GENERATED_PATH <<"/Supervisor.h";
-    std::ofstream supervisor_h(supervisor_hFName.str(), fstream::app);    // Supervisor header, open in append
-    
+    std::ofstream supervisor_h(supervisor_hFName.str().c_str(),
+                               fstream::app);    // Supervisor header, open in append
+
     if(supervisor_h.fail()) // Check that the file opened
     {                       // if it didn't, tell logserver and exit
       par->Post(816, supervisor_hFName.str(), POETS::getSysErrorString(errno));
@@ -413,7 +414,8 @@ unsigned P_builder::GenSupervisor(P_task* task)
     
     std::stringstream supervisor_cFName;
     supervisor_cFName << task_dir << "/" << GENERATED_PATH <<"/Supervisor.cpp";
-    std::ofstream supervisor_cpp(supervisor_cFName.str(), fstream::app);  // Supervisor code, open in append
+    std::ofstream supervisor_cpp(supervisor_cFName.str().c_str(),
+                                 fstream::app);  // Supervisor code, open in append
     if(supervisor_cpp.fail()) // Check that the file opened
     {                         // if it didn't, tell logserver, close .h and exit
       par->Post(816, supervisor_cFName.str(), POETS::getSysErrorString(errno));
@@ -680,7 +682,7 @@ unsigned P_builder::WriteCoreVars(std::string& task_dir, unsigned coreNum,
   std::stringstream vars_cppFName;
   vars_cppFName << task_dir << GENERATED_CPP_PATH;
   vars_cppFName << "/vars_" << coreNum << ".cpp";
-  std::ofstream vars_cpp(vars_cppFName.str());            // variables source
+  std::ofstream vars_cpp(vars_cppFName.str().c_str());  // variables source
   if(vars_cpp.fail()) // Check that the file opened
   {                       // if it didn't, tell logserver and exit
     par->Post(816, vars_cppFName.str(), POETS::getSysErrorString(errno));
@@ -690,7 +692,7 @@ unsigned P_builder::WriteCoreVars(std::string& task_dir, unsigned coreNum,
   std::stringstream handlers_hFName;
   handlers_hFName << task_dir << GENERATED_H_PATH;
   handlers_hFName << "/handlers_" << coreNum << ".h";
-  std::ofstream handlers_h(handlers_hFName.str());      // handlers header
+  std::ofstream handlers_h(handlers_hFName.str().c_str());  // handlers header
   if(handlers_h.fail()) // Check that the file opened
   {                       // if it didn't, tell logserver and exit
     par->Post(816, handlers_hFName.str(), POETS::getSysErrorString(errno));
@@ -701,7 +703,7 @@ unsigned P_builder::WriteCoreVars(std::string& task_dir, unsigned coreNum,
   std::stringstream handlers_cppFName;
   handlers_cppFName << task_dir << GENERATED_CPP_PATH;
   handlers_cppFName << "/handlers_" << coreNum << ".cpp";
-  std::ofstream handlers_cpp(handlers_cppFName.str());  // handlers source
+  std::ofstream handlers_cpp(handlers_cppFName.str().c_str());  // handlers source
   if(handlers_cpp.fail()) // Check that the file opened
   {                       // if it didn't, tell logserver and exit
     par->Post(816, handlers_cppFName.str(), POETS::getSysErrorString(errno));
@@ -1059,7 +1061,7 @@ unsigned P_builder::WriteThreadVars(string& task_dir, unsigned coreNum,
   std::stringstream vars_cppFName;
   vars_cppFName << task_dir << GENERATED_CPP_PATH;
   vars_cppFName << "/vars_" << coreNum << "_" <<thread_num << ".cpp";
-  std::ofstream vars_cpp(vars_cppFName.str());            // variables source
+  std::ofstream vars_cpp(vars_cppFName.str().c_str());  // variables source
   if(vars_cpp.fail()) // Check that the file opened
   {                       // if it didn't, tell logserver and exit
     par->Post(816, vars_cppFName.str(), POETS::getSysErrorString(errno));

--- a/Source/OrchBase/P_builder.h
+++ b/Source/OrchBase/P_builder.h
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include "OrchBase.h"
+#include "OSFixes.hpp"
 #include <fstream>
 #include <string>
 #include <cstdlib>

--- a/Source/OrchBase/P_super.cpp
+++ b/Source/OrchBase/P_super.cpp
@@ -55,8 +55,8 @@ void P_super::Attach(P_board* targetBoard)
     // Get the index of this supervisor in the box that contains this board.
     P_box* parentBox = targetBoard->parent;
     std::vector<P_super*>::iterator supervisorIterator;
-    supervisorIterator = std::find(std::begin(parentBox->P_superv),
-                                   std::end(parentBox->P_superv), this);
+    supervisorIterator = std::find(parentBox->P_superv.begin(),
+                                   parentBox->P_superv.end(), this);
     unsigned supervisorIndex;
     // We found it! Grab the index.
     if (supervisorIterator != parentBox->P_superv.end())
@@ -84,8 +84,8 @@ void P_super::Detach(P_board* targetBoard)
     // Get the index of this supervisor in the box that contains this board.
     P_box* parentBox = targetBoard->parent;
     std::vector<P_super*>::iterator supervisorIterator;
-    supervisorIterator = std::find(std::begin(parentBox->P_superv),
-                                   std::end(parentBox->P_superv), this);
+    supervisorIterator = std::find(parentBox->P_superv.begin(),
+                                   parentBox->P_superv.end(), this);
 
     // If we didn't find it, it's already been cleared. Let's not worry then.
     if (supervisorIterator == parentBox->P_superv.end()){return;}

--- a/Source/Parser/pdeviceinstance.cpp
+++ b/Source/Parser/pdeviceinstance.cpp
@@ -5,6 +5,8 @@
 PDeviceInstance::PDeviceInstance(bool is_supervisor, const QString &name, PIGraphObject *parent) :
     PConcreteInstance(name, is_supervisor ? QString("SDevI") : QString("DevI"), is_supervisor ? QVector<int>() : QVector<int>({STATE}), parent), device(NULL), supervisor(NULL), device_type_id(""), device_type(NULL), supervisor_type(NULL)
 {
+    valid_elements["S"] = STATE;
+
     if (is_supervisor && parent)
     {
         device_type_id = name;

--- a/Source/Parser/pdeviceinstance.h
+++ b/Source/Parser/pdeviceinstance.h
@@ -31,7 +31,7 @@ private:
 
     // 'officially' state is not supported but this seems unlikely.
     enum vld_elem_types {OTHER, STATE};
-    const QHash<QString, vld_elem_types> valid_elements = {{"S", STATE}};
+    QHash<QString, vld_elem_types> valid_elements;
 };
 
 #endif // PDEVICEINSTANCE_H

--- a/Source/Parser/pdevicetype.cpp
+++ b/Source/Parser/pdevicetype.cpp
@@ -6,7 +6,13 @@
 PDeviceType::PDeviceType(const QString& name, PIGraphObject *parent) :
     PConcreteDef(name, "DeviceType", QVector<int>({INPIN, OUTPIN, STATE, CODE}), parent), device_type(NULL)
 {
-
+    valid_elements["InputPin"] = INPIN;
+    valid_elements["OutputPin"] = OUTPIN;
+    valid_elements["State"] = STATE;
+    valid_elements["SharedCode"] = CODE;
+    valid_elements["DeviceSharedCode"] = CODE;
+    valid_elements["ReadyToSend"] = CODE;
+    valid_elements["OnCompute"] = CODE;
 }
 
 const PIGraphObject* PDeviceType::appendSubObject(QXmlStreamReader* xml_def)

--- a/Source/Parser/pdevicetype.h
+++ b/Source/Parser/pdevicetype.h
@@ -19,7 +19,7 @@ public:
 
 private:
     P_devtyp* device_type;
-    const QHash<QString, vld_elem_types> valid_elements = {{"InputPin", INPIN}, {"OutputPin", OUTPIN}, {"State", STATE}, {"SharedCode", CODE}, {"DeviceSharedCode", CODE}, {"ReadyToSend", CODE}, {"OnCompute", CODE}};
+    QHash<QString, vld_elem_types> valid_elements;
 };
 
 #endif // PDEVICETYPE_H

--- a/Source/Parser/pedgeinstance.cpp
+++ b/Source/Parser/pedgeinstance.cpp
@@ -7,7 +7,7 @@
 
 PEdgeInstance::PEdgeInstance(const QString& name, PIGraphObject *parent) : PConcreteInstance(name, "EdgeI", QVector<int>({STATE}), parent), containing_graph(NULL)
 {
-
+    valid_elements["S"] = STATE;
 }
 
 void PEdgeInstance::defineObject(QXmlStreamReader* xml_def)
@@ -61,7 +61,7 @@ void PEdgeInstance::elaborateEdge(D_graph* graph_rep)
      {
         PIGraphInstance* parent_instance = dynamic_cast<PIGraphInstance*>(parent());
         if (parent_instance && (parent_instance->graph_type != NULL)) // no parent instance would be a serious elaboration error
-        {           
+        {
            // generate or retrieve all the objects required to insert the node into the graph
            if (path.dst.device == NULL) parsePath(); // build the path if it couldn't be done earlier
            P_pin* src_pin = new P_pin(graph_rep, path.src.pin->name().toStdString());

--- a/Source/Parser/pedgeinstance.h
+++ b/Source/Parser/pedgeinstance.h
@@ -54,7 +54,7 @@ private:
 
     D_graph* containing_graph;
     enum vld_elem_types {OTHER, STATE};
-    const QHash<QString, vld_elem_types> valid_elements = {{"S", STATE}};
+    QHash<QString, vld_elem_types> valid_elements;
 };
 
 #endif // PEDGEINSTANCE_H

--- a/Source/Parser/pidatatype.cpp
+++ b/Source/Parser/pidatatype.cpp
@@ -3,6 +3,14 @@
 PIDataType::PIDataType(const QString& name, PIGraphObject *parent) :
     PIGraphBranch(name, "DataType", QVector<int>({DTYPE}), parent), data_type(NULL), base_type(""), expanded_type(""), value(""), default_value(""), _documentation(""), num_replications(0)
 {
+    valid_elements["Scalar"] = SCALAR;
+    valid_elements["Array"] = ARRAY;
+    valid_elements["Tuple"] = STRUCT;
+    valid_elements["Union"] = UNION;
+    valid_elements["State"] = DTYPE;
+    valid_elements["Properties"] = DTYPE;
+    valid_elements["Message"] = DTYPE;
+
     // we will do something more sensible with this in future when a PoetsDataType is better defined.
     data_type = new PoetsDataType(dynamic_cast<PIGraphObject*>(this));
 }
@@ -231,4 +239,3 @@ const QString& PIDataType::defaultValue() const
     return default_value;
     }
 }
-

--- a/Source/Parser/pidatatype.h
+++ b/Source/Parser/pidatatype.h
@@ -47,7 +47,7 @@ private:
     QString _documentation;
     int num_replications;
 
-    const QHash<QString, vld_elem_types> valid_elements = {{"Scalar", SCALAR}, {"Array", ARRAY}, {"Tuple", STRUCT}, {"Union", UNION}, {"State", DTYPE}, {"Properties", DTYPE}, {"Message", DTYPE}};
+    QHash<QString, vld_elem_types> valid_elements;
 };
 
 #endif // PIDATATYPE_H

--- a/Source/Parser/pigraphinstance.cpp
+++ b/Source/Parser/pigraphinstance.cpp
@@ -5,7 +5,8 @@
 PIGraphInstance::PIGraphInstance(const QString& name, PIGraphObject *parent) :
     PConcreteInstance(name, "GraphInstance", QVector<int>({DEVINSTS, EDGEINSTS, SUPERINSTS}), parent), graph_type(NULL), supervisor(NULL), graph_instance(NULL), graph_type_id(""), supervisor_type_id("")
 {
-
+    valid_elements["DeviceInstances"] = DEVINSTS;
+    valid_elements["EdgeInstances"] = EDGEINSTS;
 }
 
 void PIGraphInstance::defineObject(QXmlStreamReader* xml_def)
@@ -161,4 +162,3 @@ P_task* PIGraphInstance::elaborateGraphInstance(OrchBase* orch_root)
       }
       return graph_instance;
 }
-

--- a/Source/Parser/pigraphinstance.h
+++ b/Source/Parser/pigraphinstance.h
@@ -31,7 +31,7 @@ private:
     QString graph_type_id;
     QString supervisor_type_id;
 
-    const QHash<QString, vld_elem_types> valid_elements = {{"DeviceInstances", DEVINSTS}, {"EdgeInstances", EDGEINSTS}};
+    QHash<QString, vld_elem_types> valid_elements;
 
 };
 

--- a/Source/Parser/pigraphroot.cpp
+++ b/Source/Parser/pigraphroot.cpp
@@ -6,7 +6,12 @@
 
 PIGraphRoot::PIGraphRoot(const QString& name, QObject *parent) : PIGraphBranch(name, "Graphs", QVector<int>({HEADER, GTYPE, GINST, METAP}), parent), orchestrator(NULL), obj_id_counter(0), xml_hdr("")
 {
-
+     valid_elements["Pheader"] = HEADER;
+     valid_elements["GraphType"] = GTYPE;
+     valid_elements["GraphTypeReference"] = GTREF;
+     valid_elements["GraphInstance"] = GINST;
+     valid_elements["GraphInstanceReference"] = GIREF;
+     valid_elements["GraphInstanceMetadataPatch"] = METAP;
 }
 
 void PIGraphRoot::defineObject(QXmlStreamReader* xml_def)

--- a/Source/Parser/pigraphroot.h
+++ b/Source/Parser/pigraphroot.h
@@ -20,7 +20,7 @@ private:
     OrchBase* orchestrator;
     int obj_id_counter;
     QString xml_hdr;
-    const QHash<QString, vld_elem_types> valid_elements = {{"Pheader", HEADER}, {"GraphType", GTYPE}, {"GraphTypeReference", GTREF}, {"GraphInstance", GINST}, {"GraphInstanceReference", GIREF}, {"GraphInstanceMetadataPatch", METAP}};
+    QHash<QString, vld_elem_types> valid_elements;
 };
 
 #endif // PIGRAPHROOT_H

--- a/Source/Parser/pigraphtype.cpp
+++ b/Source/Parser/pigraphtype.cpp
@@ -7,7 +7,9 @@
 PIGraphType::PIGraphType(const QString& name, PIGraphObject *parent) :
     PConcreteDef(name, "GraphType", QVector<int>({DEVTYPES, SUPERDEVTYPES, MSGTYPES, SHAREDCODE}), parent), graph_type(NULL)
 {
-
+    valid_elements["DeviceTypes"] = DEVTYPES;
+    valid_elements["MessageTypes"] = MSGTYPES;
+    valid_elements["SharedCode"] = SHAREDCODE;
 }
 
 const PIGraphObject* PIGraphType::appendSubObject(QXmlStreamReader* xml_def)

--- a/Source/Parser/pigraphtype.h
+++ b/Source/Parser/pigraphtype.h
@@ -18,7 +18,7 @@ public:
 private:
 
     P_typdcl* graph_type; // need to store the graph type here for GraphInstances to recover.
-    const QHash<QString, vld_elem_types> valid_elements = {{"DeviceTypes", DEVTYPES}, {"MessageTypes", MSGTYPES}, {"SharedCode", SHAREDCODE}};
+    QHash<QString, vld_elem_types> valid_elements;
 };
 
 #endif // PIGRAPHDEF_H

--- a/Source/Parser/piinputpin.cpp
+++ b/Source/Parser/piinputpin.cpp
@@ -3,7 +3,8 @@
 
 PIInputPin::PIInputPin(const QString& name, PIGraphObject *parent) : PConcreteDef(name, "InputPin", QVector<int>({ONRECEIVE, STATE}), parent), PIPin(parent)
 {
-
+    valid_elements["OnReceive"] = ONRECEIVE;
+    valid_elements["State"] = STATE;
 }
 
 void PIInputPin::defineObject(QXmlStreamReader* xml_def)

--- a/Source/Parser/piinputpin.h
+++ b/Source/Parser/piinputpin.h
@@ -17,7 +17,7 @@ public:
 
     enum vld_elem_types {OTHER, ONRECEIVE, STATE};
 private:
-    const QHash<QString, vld_elem_types> valid_elements = {{"OnReceive", ONRECEIVE}, {"State", STATE}};
+    QHash<QString, vld_elem_types> valid_elements;
 };
 
 #endif // PIINPUTPIN_H

--- a/Source/Parser/pioutputpin.cpp
+++ b/Source/Parser/pioutputpin.cpp
@@ -2,7 +2,7 @@
 
 PIOutputPin::PIOutputPin(const QString& name, PIGraphObject *parent) : PAnnotatedDef(name, "OutputPin", QVector<int>({ONSEND}), parent), PIPin(parent)
 {
-
+    valid_elements["OnSend"] = ONSEND;
 }
 
 void PIOutputPin::defineObject(QXmlStreamReader* xml_def)

--- a/Source/Parser/pioutputpin.h
+++ b/Source/Parser/pioutputpin.h
@@ -18,7 +18,7 @@ public:
 
 private:
     enum vld_elem_types {OTHER, ONSEND};
-    const QHash<QString, vld_elem_types> valid_elements = {{"OnSend", ONSEND}};
+    QHash<QString, vld_elem_types> valid_elements;
 };
 
 #endif // PIOUTPUTPIN_H

--- a/Source/Parser/pmessagetype.cpp
+++ b/Source/Parser/pmessagetype.cpp
@@ -3,7 +3,7 @@
 
 PMessageType::PMessageType(const QString& name, PIGraphObject *parent) : PAnnotatedDef(name, "MessageType", QVector<int>({MSG}), parent), message_type(NULL)
 {
-
+    valid_elements["Message"] = MSG;
 }
 
 const PIGraphObject* PMessageType::appendSubObject(QXmlStreamReader* xml_def)

--- a/Source/Parser/pmessagetype.h
+++ b/Source/Parser/pmessagetype.h
@@ -16,7 +16,7 @@ public:
 private:
     P_message* message_type;
     enum vld_elem_types {OTHER, MSG};
-    const QHash<QString, vld_elem_types> valid_elements = {{"Message", MSG}};
+    QHash<QString, vld_elem_types> valid_elements;
 };
 
 #endif // PMESSAGETYPE_H

--- a/Source/Parser/poetsdatatype.cpp
+++ b/Source/Parser/poetsdatatype.cpp
@@ -2,5 +2,52 @@
 
 PoetsDataType::PoetsDataType(QObject* parent) : QObject(parent), QVariant()
 {
+    vld_types["char"] = ISCALAR;
+    vld_types["short"] = ISCALAR;
+    vld_types["int"] = ISCALAR;
+    vld_types["long"] = ISCALAR;
+    vld_types["long long"] = ISCALAR;
+    vld_types["unsigned char"] = USCALAR;
+    vld_types["unsigned short"] = USCALAR;
+    vld_types["unsigned int"] = USCALAR;
+    vld_types["unsigned long"] = USCALAR;
+    vld_types["unsigned long long"] = USCALAR;
+    vld_types["int8_t"] = ISCALAR;
+    vld_types["int16_t"] = ISCALAR;
+    vld_types["int32_t"] = ISCALAR;
+    vld_types["int64_t"] = ISCALAR;
+    vld_types["uint8_t"] = USCALAR;
+    vld_types["uint16_t"] = USCALAR;
+    vld_types["uint32_t"] = USCALAR;
+    vld_types["uint64_t"] = USCALAR;
+    vld_types["float"] = FSCALAR;
+    vld_types["double"] = FSCALAR;
+    vld_types["long double"] = FSCALAR;
+    vld_types["char*"] = SSCALAR;
+    vld_types["string"] = SSCALAR;
+    vld_types["union"] = UNION;
+    vld_types["struct"] = STRUCT;
 
+    type_sizes["char"] = sizeof(char);
+    type_sizes["short"] = sizeof(short);
+    type_sizes["int"] = sizeof(int);
+    type_sizes["long"] = sizeof(long);
+    type_sizes["long long"] = sizeof(long long);
+    type_sizes["unsigned char"] = sizeof(unsigned char);
+    type_sizes["unsigned short"] = sizeof(unsigned short);
+    type_sizes["unsigned int"] = sizeof(unsigned int);
+    type_sizes["unsigned long"] = sizeof(unsigned long);
+    type_sizes["unsigned long long"] = sizeof(unsigned long long);
+    type_sizes["int8_t"] = sizeof(int8_t);
+    type_sizes["int16_t"] = sizeof(int16_t);
+    type_sizes["int32_t"] = sizeof(int32_t);
+    type_sizes["int64_t"] = sizeof(int64_t);
+    type_sizes["uint8_t"] = sizeof(uint8_t);
+    type_sizes["uint16_t"] = sizeof(uint16_t);
+    type_sizes["uint32_t"] = sizeof(uint32_t);
+    type_sizes["uint64_t"] = sizeof(uint64_t);
+    type_sizes["float"] = sizeof(float);
+    type_sizes["double"] = sizeof(double);
+    type_sizes["long double"] = sizeof(long double);
+    type_sizes["char*"] = sizeof(char*);
 }

--- a/Source/Parser/poetsdatatype.h
+++ b/Source/Parser/poetsdatatype.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QVariant>
+#include "OSFixes.hpp"
 
 class PoetsDataType : public QObject, public QVariant
 {
@@ -11,14 +12,10 @@ public:
 
     enum dtype_classes {ISCALAR, USCALAR, FSCALAR, SSCALAR, ARRAY, STRUCT, UNION};
 
-    const QHash<QString, dtype_classes> vld_types = {{"char", ISCALAR}, {"short", ISCALAR}, {"int", ISCALAR}, {"long", ISCALAR}, {"long long", ISCALAR}, {"unsigned char", USCALAR}, {"unsigned short", USCALAR}, {"unsigned int", USCALAR}, {"unsigned long", USCALAR}, {"unsigned long long", USCALAR}, {"int8_t", ISCALAR},
-                                                            {"int16_t", ISCALAR}, {"int32_t", ISCALAR}, {"int64_t", ISCALAR}, {"uint8_t", USCALAR}, {"uint16_t", USCALAR}, {"uint32_t", USCALAR}, {"uint64_t", USCALAR},
-                                                            {"float", FSCALAR}, {"double", FSCALAR}, {"long double", FSCALAR}, {"char*", SSCALAR}, {"string", SSCALAR}, {"union", UNION}, {"struct", STRUCT}};
-    const QHash<QString, size_t> type_sizes = {{"char", sizeof(char)}, {"short", sizeof(short)}, {"int", sizeof(int)}, {"long", sizeof(long)}, {"long long", sizeof(long long)}, {"unsigned char", sizeof(unsigned char)}, {"unsigned short", sizeof(unsigned short)}, {"unsigned int", sizeof(unsigned int)},
-                                               {"unsigned long", sizeof(unsigned long)}, {"unsigned long long", sizeof(unsigned long long)}, {"int8_t", sizeof(int8_t)}, {"int16_t", sizeof(int16_t)}, {"int32_t", sizeof(int32_t)}, {"int64_t", sizeof(int64_t)}, {"uint8_t", sizeof(uint8_t)},
-                                               {"uint16_t", sizeof(uint16_t)}, {"uint32_t", sizeof(uint32_t)}, {"uint64_t", sizeof(uint64_t)}, {"float", sizeof(float)}, {"double", sizeof(double)}, {"long double", sizeof(long double)}, {"char*", sizeof(char*)}};
+    QHash<QString, dtype_classes> vld_types;
+    QHash<QString, size_t> type_sizes;
 
-/*    const QHash<int, QVector<QString>*> vld_typ_classes = {{ISCALAR, &int_scalars}, {FSCALAR, &float_scalars}, {SSCALAR, &string_scalars}, {STRUCT, &_unions}, {UNION, &_structs}};
+/*    QHash<int, QVector<QString>*> vld_typ_classes = {{ISCALAR, &int_scalars}, {FSCALAR, &float_scalars}, {SSCALAR, &string_scalars}, {STRUCT, &_unions}, {UNION, &_structs}};
 
 private:
     const QVector<QString> int_scalars = {"char", "short", "int", "long", "long long", "unsigned char", "unsigned short", "unsigned int", "unsigned long", "unsigned long long", "int8_t", "int16_t", "int32_t", "int64_t", "uint8_t", "uint16_t", "uint32_t", "uint64_t"};

--- a/Source/Parser/psupervisordevicetype.cpp
+++ b/Source/Parser/psupervisordevicetype.cpp
@@ -7,7 +7,9 @@ PSupervisorDeviceType::PSupervisorDeviceType(const QString& name, PIGraphObject 
     PIGraphBranch(name, "SupervisorDeviceType", QVector<int>({INPIN, OUTPIN, CODE}), parent),
     dev_info_persistent(false), dev_props_valid(false), edge_endpts_exist(false), device_type(0)
 {
-
+    valid_elements["InputPin"] = INPIN;
+    valid_elements["OutputPin"] = OUTPIN;
+    valid_elements["Code"] = CODE;
 }
 
 void PSupervisorDeviceType::defineObject(QXmlStreamReader* xml_def)

--- a/Source/Parser/psupervisordevicetype.h
+++ b/Source/Parser/psupervisordevicetype.h
@@ -22,7 +22,7 @@ public:
 
 private:
     P_devtyp* device_type;
-    const QHash<QString, vld_elem_types> valid_elements = {{"InputPin", INPIN}, {"OutputPin", OUTPIN}, {"Code", CODE}};
+    QHash<QString, vld_elem_types> valid_elements;
 };
 
 #endif // PSUPERVISORDEVICETYPE_H


### PR DESCRIPTION
See title. Probably not without flaws. Things that are not compatible include:

 - Parser (about to be overwritten by ADB)
 - Mothership

Compatibility tested by changing the CXXFLAGS variable in the Makefile to `-std=C++98` when compiling the other bits, running the test suite, and running the 40x40 plate on Byron, which gave the attached output in 235 seconds.
[plate_40x40_out.txt](https://github.com/POETSII/Orchestrator/files/3478213/plate_40x40_out.txt)

Once accepted, @heliosfa will kindly merge and deploy to the shared drive so that ADB can have a poke (please let me and ADB know once you have done this).