### PR TITLE
Parallel compilation of the device binaries

### DIFF
--- a/Source/OrchBase/build_defs.cpp
+++ b/Source/OrchBase/build_defs.cpp
@@ -37,6 +37,6 @@ const string TINSEL_SRC_PATH = STATIC_SRC_PATH+TINSEL_PATH;
 const string ORCH_SRC_PATH = STATIC_SRC_PATH+ORCH_PATH;
 const string BIN_PATH = "bin";
 const string BUILD_PATH = "Build";
-const string COREMAKE_BASE = "make -j -l$(nproc --ignore=2) all 2>&1 >> make_errs.txt";
+const string COREMAKE_BASE = "make -j$(nproc --ignore=4) all 2>&1 >> make_errs.txt";
 const string COREBIN_BASE = "softswitch_";
 const void* DRAM_BASE = 0; // temporary: this should be set to the actual DRAM bottom address.

--- a/Source/OrchBase/build_defs.cpp
+++ b/Source/OrchBase/build_defs.cpp
@@ -37,6 +37,6 @@ const string TINSEL_SRC_PATH = STATIC_SRC_PATH+TINSEL_PATH;
 const string ORCH_SRC_PATH = STATIC_SRC_PATH+ORCH_PATH;
 const string BIN_PATH = "bin";
 const string BUILD_PATH = "Build";
-const string COREMAKE_BASE = "make all 2>&1 >> make_errs.txt";
+const string COREMAKE_BASE = "make -j -l$(nproc --ignore=2) all 2>&1 >> make_errs.txt";
 const string COREBIN_BASE = "softswitch_";
 const void* DRAM_BASE = 0; // temporary: this should be set to the actual DRAM bottom address.


### PR DESCRIPTION
This change implements #28 - enabling parallel compilation of the device binaries automagially.

This uses a thread count of up to the number of cores available to the user, less 4 if possible (to give some breathing room for other Orchestrator processes). `nproc` will always return at least `1` so this works on systems with <=4 cores.

For a 1000x1000 plate on Byron (28 logical processors), this reduces the compilation time from around half an hour to under 3 minutes (2:40) and generates identical binaries.