### PR TITLE
Fix Supervisor build warnings

### DIFF
--- a/Source/Mothership/Supervisor.cpp
+++ b/Source/Mothership/Supervisor.cpp
@@ -57,17 +57,21 @@ int SupervisorInit()
 
 #endif
 
-supInputPin::supInputPin(Sup_OnReceive_t recvHandler, const void* props, void* st)
+supInputPin::supInputPin(Sup_OnReceive_t recvHandler, 
+                         Sup_PinTeardown_t pinTeardown, 
+                         const void* props, void* st)
 {
       OnReceive = recvHandler;
+      PinTeardown = pinTeardown;
       properties = props;
       state = st;
 }
 
 supInputPin::~supInputPin()
 {
-     if (properties) delete properties;
-     if (state) delete state;
+    if(PinTeardown) PinTeardown(properties, state);
+    //if (properties) delete properties;
+    //if (state) delete state;
 }
 
 supOutputPin::supOutputPin(Sup_OnSend_t sendHandler)

--- a/Source/Mothership/Supervisor.h
+++ b/Source/Mothership/Supervisor.h
@@ -6,15 +6,18 @@
 typedef unsigned (*Sup_OnReceive_t) (const void*, void*, const P_Sup_Msg_t*, PMsg_p*, void*);
 // OnSend takes the message buffer and an indication of whether it's a supervisor message
 typedef unsigned (*Sup_OnSend_t) (PMsg_p*, void*, unsigned);
+// Gracefully handle tearing down a pin.
+typedef unsigned (*Sup_PinTeardown_t) (const void*, void*);
 
 class supInputPin
 {
 public:
 
-      supInputPin(Sup_OnReceive_t, const void*, void*);
+      supInputPin(Sup_OnReceive_t, Sup_PinTeardown_t, const void*, void*);
       ~supInputPin();
   
       Sup_OnReceive_t OnReceive;
+      Sup_PinTeardown_t PinTeardown;
       const void* properties;
       void* state;
 };

--- a/Source/OrchBase/P_builder.cpp
+++ b/Source/OrchBase/P_builder.cpp
@@ -534,10 +534,37 @@ unsigned P_builder::GenSupervisor(P_task* task)
       sup_pin_handlers << "   return 0;\n";
       sup_pin_handlers << "}\n\n";
       
+      
+      //========================================================================
+      // Add the pin's teardown code
+      //========================================================================
+      sup_pin_handlers << "unsigned super_InPin_" << sIpin_name;
+      sup_pin_handlers << "_PinTeardown (const void* pinProps, ";
+      sup_pin_handlers << "void* pinState)\n";
+      sup_pin_handlers << "{\n";
+      
+      if ((*sI_pin)->pPropsD)
+      {
+        sup_pin_handlers << "    delete static_cast<const super_InPin_";
+        sup_pin_handlers << sIpin_name << "_props_t*>(pinProps);\n";        
+      }
+      
+      if ((*sI_pin)->pStateD)
+      {
+        sup_pin_handlers << "    delete static_cast<super_InPin_";
+        sup_pin_handlers << sIpin_name << "_state_t*>(pinState);\n";
+      }
+      
+      sup_pin_handlers << "    return 0;\n";
+      sup_pin_handlers << "}\n\n";
+      //========================================================================
+      
+      
       // this will create a new pin object - how should this be deleted on exit since it's held in a static class member?
       sup_pin_vectors << "Supervisor::inputs.push_back";
       sup_pin_vectors << "(new supInputPin(";
       sup_pin_vectors << "&super_InPin_" << sIpin_name << "_Recv_handler,";
+      sup_pin_vectors << "&super_InPin_" << sIpin_name << "_PinTeardown,";
       sup_pin_vectors << sup_inPin_props.str() << ",";
       sup_pin_vectors << sup_inPin_state.str();
       sup_pin_vectors << "));\n";

--- a/Source/OrchBase/P_builder.cpp
+++ b/Source/OrchBase/P_builder.cpp
@@ -536,7 +536,8 @@ unsigned P_builder::GenSupervisor(P_task* task)
       
       
       //========================================================================
-      // Add the pin's teardown code
+      // Add the pin's teardown code - this deletes the properties and state if 
+      // they exist. Called by the destructor for supInputPin in Supervisor.cpp
       //========================================================================
       sup_pin_handlers << "unsigned super_InPin_" << sIpin_name;
       sup_pin_handlers << "_PinTeardown (const void* pinProps, ";


### PR DESCRIPTION
This merge addresses #18 by adding a pointer to a "handler" to `supInputPin` that is called in its destructor. This handler gracefully tearsdown the properties and state of a supervisor's input pin. P_builder auto-generates this handler (and adds the appropriate references to it) for each pin.

This has been tested on Fielding with a 40x40 plate for build warnings (there are none) and clean-exiting (it does).