### PR TITLE
Borland, go home, you are drunk

### DIFF
--- a/Source/Common/OSFixes.hpp
+++ b/Source/Common/OSFixes.hpp
@@ -28,7 +28,9 @@
  #include <cinttypes>
 #else
  #include <stdint.h>
- #include <inttypes.h>
+  #ifndef __BORLANDC__        // Borland doesn't know about inttypes.h, 
+   #include <inttypes.h>      // despite knowing about stdint.h...
+  #endif
  #include <sstream>
 #endif
 


### PR DESCRIPTION
Despite having some support for C99 (e.g. `stdint.h` for fixed-width ints), Borland does not know about `inttypes.h` so complains bitterly. If you remove `inttypes.h`, Borland will happily ignore the missing `PRIx??` identifiers and work.

Not having `inttypes.h` makes MSVC complain bitterly about a missing `)` because it does not know about `PRIx32` without it and it doesn't treat the identifier as a blank like Borland does.

This change removes `inttypes.h` from Borland compiles while leaving it for MSVC ones - everyone is happy! 