### PR TITLE
Fixed bug 93 by adding an iterator init to the placement of a virtual…

### DIFF
--- a/Source/OrchBase/P_builder.cpp
+++ b/Source/OrchBase/P_builder.cpp
@@ -167,6 +167,7 @@ void P_builder::Preplace(P_task* task)
       MultiSimpleDeployer deployer(numBoxes);
       par->Post(138,par->pE->Name());
       deployer.deploy(par->pE);
+      par->pPlace->Init();
     }
     if (!par->pPlace->Place(task)) task->LinkFlag(); // then preplace on the real or virtual board.
   }


### PR DESCRIPTION
This fixes bug#93 [https://github.com/POETSII/Orchestrator/issues/93](url) regarding segfault when you try to do a task /build without setting topology. See additional notes in the bug report itself for details on the problem and its resolution.