### PR TITLE
fixes for bug 115 (crash when a device/pin type is wrong in an edge instance)

### DIFF
--- a/OrchestratorFrontEnd.pro
+++ b/OrchestratorFrontEnd.pro
@@ -43,35 +43,58 @@ SOURCES += \
     ./Source/Root/Root.cpp \
     ./Source/Root/RootMain.cpp \
     ./Source/OrchBase/Bin.cpp \
+    ./Source/OrchBase/build_defs.cpp \
+    ./Source/OrchBase/CMsg_p.cpp \
     ./Source/OrchBase/CFrag.cpp \
-    ./Source/OrchBase/Config_t.cpp \
     ./Source/OrchBase/Constraints.cpp \
     ./Source/OrchBase/D_graph.cpp \
-    ./Source/OrchBase/OrchBase.cpp \
-    ./Source/OrchBase/P_board.cpp \
-    ./Source/OrchBase/P_box.cpp \
-    ./Source/OrchBase/P_builder.cpp \
-    ./Source/OrchBase/P_core.cpp \
+    ./Source/OrchBase/OrchBase.cpp \   
+    ./Source/OrchBase/HardwareConfigurationDeployment/MultiSimpleDeployer.cpp \
+    ./Source/OrchBase/HardwareConfigurationDeployment/SimpleDeployer.cpp \
+    ./Source/OrchBase/HardwareConfigurationDeployment/Dialect1Deployer.cpp \
+    ./Source/OrchBase/HardwareFileReader/HardwareFileReaderCore.cpp \
+    ./Source/OrchBase/HardwareFileReader/HardwareFileReaderDialect1.cpp \
+    ./Source/OrchBase/HardwareFileReader/HardwareFileReaderDialect3.cpp \
+    ./Source/OrchBase/HardwareFileReader/HardwareFileReaderDialect3Engine.cpp \
+    ./Source/OrchBase/HardwareFileReader/HardwareFileReaderDialect3Getters.cpp \
+    ./Source/OrchBase/HardwareFileReader/HardwareFileReaderDialect3Items.cpp \
+    ./Source/OrchBase/HardwareFileReader/HardwareFileReaderDialect3Sections.cpp \
+    ./Source/OrchBase/HardwareFileReader/Validator.cpp \
     ./Source/OrchBase/P_device.cpp \
+    ./Source/OrchBase/P_builder.cpp \
     ./Source/OrchBase/P_devtyp.cpp \
-    ./Source/OrchBase/P_graph.cpp \
-    ./Source/OrchBase/P_link.cpp \
     ./Source/OrchBase/P_message.cpp \
+    ./Source/OrchBase/P_owner.cpp \
     ./Source/OrchBase/P_pin.cpp \
     ./Source/OrchBase/P_pintyp.cpp \
-    ./Source/OrchBase/P_port.cpp \
     ./Source/OrchBase/P_task.cpp \
-    ./Source/OrchBase/P_thread.cpp \
     ./Source/OrchBase/P_typdcl.cpp \
     ./Source/OrchBase/Placement.cpp \
     ./Source/OrchBase/T_gen.cpp \
     ./Source/OrchBase/P_addr.cpp \
+    ./Source/OrchBase/P_super.cpp \
     ./Source/Common/CommonBase.cpp \
+    ./Source/Common/Debug.cpp \
+    ./Source/Common/DumpUtils.cpp \
     ./Source/Common/Environment.cpp \
-    ./Source/Common/NameBase.cpp \
+    ./Source/Common/P_frame.cpp \
+    ./Source/Common/Pglobals.cpp \
     ./Source/Common/PMsg_p.cpp \
     ./Source/Common/ProcMap.cpp \
+    ./Source/Common/SoftwareAddress.cpp \
     ./Source/Common/Unrec_t.cpp \
+    ./Source/Common/HardwareModel/AddressableItem.cpp \
+    ./Source/Common/HardwareModel/HardwareAddress.cpp \
+    ./Source/Common/HardwareModel/HardwareAddressFormat.cpp \
+    ./Source/Common/HardwareModel/HardwareIterator.cpp \
+    ./Source/Common/HardwareModel/P_board.cpp \
+    ./Source/Common/HardwareModel/P_box.cpp \
+    ./Source/Common/HardwareModel/P_core.cpp \
+    ./Source/Common/HardwareModel/P_engine.cpp \
+    ./Source/Common/HardwareModel/P_link.cpp \
+    ./Source/Common/HardwareModel/P_mailbox.cpp \
+    ./Source/Common/HardwareModel/P_thread.cpp \
+    ./Source/Common/HardwareModel/P_port.cpp \
     ./Generics/Cli.cpp \
     ./Generics/dfprintf.cpp \
     ./Generics/dumpchan.cpp \
@@ -83,16 +106,11 @@ SOURCES += \
     ./Generics/map2.tpp \
     ./Generics/Msg_p.cpp \
     ./Generics/Msg_p.tpp \
+    ./Generics/NameBase.cpp \
     ./Generics/pdigraph.tpp \
     ./Generics/rand.cpp \
     ./Generics/uif.cpp \
-    Source/Common/Pglobals.cpp \
-    Source/OrchBase/P_super.cpp \
-    Source/NameServer/Ns_el.cpp \
-    Source/OrchBase/P_owner.cpp \
-    Source/OrchBase/build_defs.cpp \
-    Source/OrchBase/CMsg_p.cpp
-
+    ./Source/NameServer/Ns_el.cpp
 
 # The following define makes your compiler emit warnings if you use
 # any feature of Qt which as been marked deprecated (the exact warnings
@@ -110,7 +128,7 @@ HEADERS += \
     ./Source/Parser/orchbasedummy.h \
     ./Source/Parser/pannotateddef.h \
     ./Source/Parser/pcodefragment.h \
-    ./Source/Parser/ pconcretedef.h \
+    ./Source/Parser/pconcretedef.h \
     ./Source/Parser/pconcreteinstance.h \
     ./Source/Parser/pdeviceinstance.h \
     ./Source/Parser/pdevicetype.h \
@@ -132,39 +150,71 @@ HEADERS += \
     ./Source/Parser/psubobjects.h \
     ./Source/Parser/psupervisordevicetype.h \
     ./Source/Root/Root.h \
+    ./Source/Root/RootArgs.h \
+    ./Source/Root/P_graph.h \
     ./Source/OrchBase/Bin.h \
+    ./Source/OrchBase/build_defs.h \
     ./Source/OrchBase/CFrag.h \
-    ./Source/OrchBase/Config_t.h \
+    ./Source/OrchBase/CMsg_p.h \
     ./Source/OrchBase/Constraints.h \
     ./Source/OrchBase/D_graph.h \
     ./Source/OrchBase/OrchBase.h \
-    ./Source/OrchBase/P_board.h \
-    ./Source/OrchBase/P_box.h \
+    ./Source/OrchBase/P_addr.h \
     ./Source/OrchBase/P_builder.h \
-    ./Source/OrchBase/P_core.h \
     ./Source/OrchBase/P_device.h \
     ./Source/OrchBase/P_devtyp.h \
-    ./Source/OrchBase/P_graph.h \
-    ./Source/OrchBase/P_link.h \
+    ./Source/OrchBase/Placement.h \
     ./Source/OrchBase/P_message.h \
+    ./Source/OrchBase/P_owner.h \
     ./Source/OrchBase/P_pin.h \
     ./Source/OrchBase/P_pintyp.h \
-    ./Source/OrchBase/P_port.h \
+    ./Source/OrchBase/P_super.h \
     ./Source/OrchBase/P_task.h \
-    ./Source/OrchBase/P_thread.h \
     ./Source/OrchBase/P_typdcl.h \
-    ./Source/OrchBase/Placement.h \
     ./Source/OrchBase/T_gen.h \
+    ./Source/OrchBase/tinsel-config.h \
+    ./Source/OrchBase/HardwareConfigurationDeployment/MultiSimpleDeployer.h \
+    ./Source/OrchBase/HardwareConfigurationDeployment/SimpleDeployer.h \
+    ./Source/OrchBase/HardwareConfigurationDeployment/Dialect1Deployer.h \
+    ./Source/OrchBase/HardwareFileReader/HardwareFileNotFoundException.h \
+    ./Source/OrchBase/HardwareFileReader/HardwareFileNotLoadedException.h \
+    ./Source/OrchBase/HardwareFileReader/HardwareFileReader.h \
+    ./Source/OrchBase/HardwareFileReader/HardwareFileReaderException.h \
+    ./Source/OrchBase/HardwareFileReader/HardwareSemanticException.h \
+    ./Source/OrchBase/HardwareFileReader/HardwareSyntaxException.h \
+    ./Source/OrchBase/HardwareFileReader/Validator.h \
     ./Source/Common/CommonBase.h \
+    ./Source/Common/Debug.h \
+    ./Source/Common/DumpUtils.h \
     ./Source/Common/Environment.h \
-    ./Source/Common/NameBase.h \
+    ./Source/Common/OrchestratorException.h \
+    ./Source/Common/OSFixes.hpp \
+    ./Source/Common/P_frame.h \
     ./Source/Common/Pglobals.h \
     ./Source/Common/PMsg_p.hpp \
     ./Source/Common/ProcMap.h \
+    ./Source/Common/SoftwareAddress.h \
     ./Source/Common/Unrec_t.h \
-    ./Source/OrchBase/P_addr.h \
+    ./Source/Common/HardwareModel/AddressableItem.h \
+    ./Source/Common/HardwareModel/HardwareAddress.h \
+    ./Source/Common/HardwareModel/HardwareAddressFormat.h \
+    ./Source/Common/HardwareModel/HardwareIterator.h \
+    ./Source/Common/HardwareModel/HardwareModel.h \
+    ./Source/Common/HardwareModel/InvalidAddressException.h \
+    ./Source/Common/HardwareModel/IteratorException.h \
+    ./Source/Common/HardwareModel/MissingAddressException.h \
+    ./Source/Common/HardwareModel/OwnershipException.h \
+    ./Source/Common/HardwareModel/P_board.h \
+    ./Source/Common/HardwareModel/P_box.h \
+    ./Source/Common/HardwareModel/P_core.h \
+    ./Source/Common/HardwareModel/P_engine.h \
+    ./Source/Common/HardwareModel/P_link.h \
+    ./Source/Common/HardwareModel/P_mailbox.h \
+    ./Source/Common/HardwareModel/P_port.h \
+    ./Source/Common/HardwareModel/P_thread.h \
     ./Generics/Cli.h \
     ./Generics/dfprintf.h \
+    ./Generics/dumpchan.h \
     ./Generics/e.h \
     ./Generics/filename.h \
     ./Generics/flat.h \
@@ -174,30 +224,28 @@ HEADERS += \
     ./Generics/macros.h \
     ./Generics/map2.h \
     ./Generics/Msg_p.hpp \
-    ./Generics/msg_p.hpp \
+    ./Generics/NameBase.h \
     ./Generics/pdigraph.hpp \
     ./Generics/rand.h \
     ./Generics/uif.h \
-    ./Source/OrchBase/build_defs.h \
-    Source/OrchBase/P_super.h \
-    Source/Injector/Injector.h \
-    Source/NameServer/Ns_el.h \
-    Source/OrchBase/P_owner.h \
-    Generics/dumpchan.h \
-    Source/OrchBase/CMsg_p.h \
-    Source/Parser/pconcretedef.h
+    ./Source/Injector/Injector.h \
+    ./Source/NameServer/Ns_el.h
 
 # mpich common install directory added
 LIBS += "-L/home/adr1r17/Prg/mpich-3.2.1/lib" "-L/usr/lib" -lmpi
 
 # mpi include path changed
 INCLUDEPATH += ./Source/Common \
+    ./Source/Common/HardwareModel \
     ./Source/OrchBase \
+    ./Source/OrchBase/HardwareConfigurationDeployment \
+    ./Source/OrchBase/HardwareFileReader \
     ./Source/Parser \
     ./Source/NameServer \
     ./Source/Injector \
     ./Generics \
-    /home/adr1r17/Prg/mpich-3.2.1/include
-    /usr/include \
+    /home/adr1r17/adr1r17_Soton/data/code/tinsel/tinsel-0.6.1/include \
+    /home/adr1r17/Prg/mpich-3.2.1/include \
+    /usr/include
     #/usr/include/mpi
 

--- a/OrchestratorFrontEnd.pro.user
+++ b/OrchestratorFrontEnd.pro.user
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.2.1, 2019-01-09T01:20:43. -->
+<!-- Written by QtCreator 4.0.3, 2019-10-29T17:13:52. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
-  <value type="QByteArray">{94a7ad5c-3708-47a9-b5f8-784327afe8d3}</value>
+  <value type="QByteArray">{9d2801a1-3d19-4382-8ead-11906f1fe1e8}</value>
  </data>
  <data>
   <variable>ProjectExplorer.Project.ActiveTarget</variable>
@@ -59,14 +59,14 @@
  <data>
   <variable>ProjectExplorer.Project.Target.0</variable>
   <valuemap type="QVariantMap">
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Desktop Qt 5.8.0 GCC 64bit</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Desktop Qt 5.8.0 GCC 64bit</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">qt.58.gcc_64_kit</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Desktop Qt 5.6.3 GCC 64bit</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Desktop Qt 5.6.3 GCC 64bit</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">qt.563.gcc_64_kit</value>
    <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">0</value>
    <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
    <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/alex_rast/adr1r17/Code/Git/build-OrchestratorFrontEnd</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/adr1r17/adr1r17_Soton/data/code/Orchestrator_QtBuild</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
@@ -126,7 +126,7 @@
     <value type="bool" key="Qt4ProjectManager.Qt4BuildConfiguration.UseShadowBuild">true</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.1">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/alex_rast/adr1r17/Code/Git/build-OrchestratorFrontEnd</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/adr1r17/adr1r17_Soton/data/code/build-OrchestratorFrontEnd-Desktop_Qt_5_6_3_GCC_64bit-Release</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
@@ -186,7 +186,7 @@
     <value type="bool" key="Qt4ProjectManager.Qt4BuildConfiguration.UseShadowBuild">true</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.2">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/alex_rast/adr1r17/Code/Git/build-OrchestratorFrontEnd</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/adr1r17/adr1r17_Soton/data/code/build-OrchestratorFrontEnd-Desktop_Qt_5_6_3_GCC_64bit-Profile</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
@@ -304,13 +304,13 @@
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">OrchestratorFrontEnd</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/home/alex_rast/adr1r17/Code/Git/Orchestrator/OrchestratorFrontEnd.pro</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/home/adr1r17/adr1r17_Soton/data/code/Orchestrator-development/OrchestratorFrontEnd.pro</value>
     <value type="bool" key="QmakeProjectManager.QmakeRunConfiguration.UseLibrarySearchPath">true</value>
     <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.CommandLineArguments"></value>
     <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.ProFile">OrchestratorFrontEnd.pro</value>
     <value type="bool" key="Qt4ProjectManager.Qt4RunConfiguration.UseDyldImageSuffix">false</value>
     <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory"></value>
-    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory.default">/home/alex_rast/adr1r17/Code/Git/build-OrchestratorFrontEnd</value>
+    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory.default">/home/adr1r17/adr1r17_Soton/data/code/Orchestrator_QtBuild</value>
     <value type="uint" key="RunConfiguration.QmlDebugServerPort">3768</value>
     <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>

--- a/Source/Mothership/Supervisor.cpp
+++ b/Source/Mothership/Supervisor.cpp
@@ -18,7 +18,8 @@ int SupervisorCall(PMsg_p* In, PMsg_p* Out)
   if (!devMsg) return -1;                                 // bad message
   for (int msg=0; msg < numMsgs; msg++)
   {
-      // run as necessary any OnReceive handler 
+      // run as necessary any OnReceive handler
+      if (devMsg[msg].header.destPin >= Supervisor::inputs.size()) return -1;  // invalid pin
       supInputPin* dest = Supervisor::inputs[devMsg[msg].header.destPin];
       // more thought needed about accumulation of error messages vs. send indications
       sentErr += dest->OnReceive(dest->properties, dest->state, &devMsg[msg], Out, outMsgBuf);

--- a/Source/Mothership/TMoth.cpp
+++ b/Source/Mothership/TMoth.cpp
@@ -813,6 +813,7 @@ unsigned TMoth::OnSuper(PMsg_p * Z, unsigned cIdx)
     W.Key(Q::SUPR);
     W.Src(Z->Tgt());
     int superReturn = 0;
+    DebugPrint("Executing Supervisor call\n");
     if ((superReturn = (*SupervisorCall)(Z,&W)) > 0) // Execute. Send a reply if one is expected
     {
         if (!cIdx && (Z->Tgt() == Urank) && (Z->Src() == Urank)) OnTinsel(&W, 0); // either to Tinsels,
@@ -902,9 +903,11 @@ unsigned TMoth::OnTinselOut(P_Sup_Msg_t * packet)
     W.Key(Q::SUPR);                            // it'll be a Supervisor packet
     W.Src(Urank);                              // coming from the us
     W.Tgt(Urank);                              // and directed at us
+    DebugPrint("Built a Supervisor packet from/to Mothership at rank %d\n", W.Src());
     unsigned last_index = packet->header.cmdLenBytes/p_sup_msg_size() + (packet->header.cmdLenBytes%p_sup_msg_size() ? 1 : 0);
     vector<P_Sup_Msg_t> pkt_v(packet,&packet[last_index]); // maybe slightly more efficient using the constructor
     W.Put<P_Sup_Msg_t>(0,&pkt_v);    // stuff the Tinsel message into the packet
+    DebugPrint("Calling Supervisor for device %u at pin %hu\n", packet->header.sourceDeviceAddr, packet->header.destPin);
     return OnSuper(&W, 0);
     // W.Send();                        // away it goes.
     // return 0;

--- a/Source/OrchestratorMessages.txt
+++ b/Source/OrchestratorMessages.txt
@@ -48,6 +48,8 @@
 111(E) : "Internal task generator has no PoL task type %s"
 112(E) : "Cannot find file %s"
 113(E) : "No graph declaration block for task %s - cannot instantiate"
+114(E) : "No or invalid device type for device %s - cannot instantiate"
+115(E) : "Invalid pin or device type for edge %s - cannot instantiate"
 131(I) : "Loading box configuration file %s"
 132(W) : "Cannot open topology dump file %s"
 133(I) : "Topology discovery %s"

--- a/Source/Parser/pconcretedef.cpp
+++ b/Source/Parser/pconcretedef.cpp
@@ -23,7 +23,7 @@ const PIGraphObject* PConcreteDef::appendSubObject(QXmlStreamReader* xml_def)
            necessary. Rather roundabout...
         */
         if (xml_def->attributes().hasAttribute("", "cTypeName"))
-                _properties = new PIDataType(xml_def->attributes().value("", "cTypeName").toString(), this);
+           _properties = new PIDataType(xml_def->attributes().value("", "cTypeName").toString(), this);
         else
         {
             QString prop_name("properties_t");

--- a/Source/Parser/pdeviceinstance.cpp
+++ b/Source/Parser/pdeviceinstance.cpp
@@ -81,17 +81,17 @@ P_device* PDeviceInstance::elaborateDeviceInstance(D_graph* graph_instance)
        if (device_type != NULL) // but it still could turn out to be empty
        {
            device->pP_devtyp = const_cast<PDeviceType*>(device_type)->elaborateDeviceType();
-       }
-       if (numSubObjects(STATE))
-       {
-           PIDataValue* devState = static_cast<PIDataValue*>(subObject(STATE, 0));
-           if (!devState->data_type) devState->data_type = static_cast<const PIDataType*>(device_type->constSubObject(PDeviceType::STATE, 0));
-           device->pStateI = static_cast<PIDataValue*>(subObject(STATE, 0))->elaborateDataValue();
-       }
-       if (properties() != NULL)
-       {
-           if (!(properties()->data_type)) setPropsDataType(device_type->properties());
-           device->pPropsI = const_cast<PIDataValue*>(properties())->elaborateDataValue();
+           if (numSubObjects(STATE))
+           {
+              PIDataValue* devState = static_cast<PIDataValue*>(subObject(STATE, 0));
+              if (!devState->data_type) devState->data_type = static_cast<const PIDataType*>(device_type->constSubObject(PDeviceType::STATE, 0));
+              device->pStateI = static_cast<PIDataValue*>(subObject(STATE, 0))->elaborateDataValue();
+           }
+          if (properties() != NULL)
+          {
+             if (!(properties()->data_type)) setPropsDataType(device_type->properties());
+             device->pPropsI = const_cast<PIDataValue*>(properties())->elaborateDataValue();
+          }
        }
     }
     return device;

--- a/Source/Parser/pedgeinstance.h
+++ b/Source/Parser/pedgeinstance.h
@@ -18,8 +18,8 @@ public:
 
     void defineObject(QXmlStreamReader* xml_def);
     const PIGraphObject* appendSubObject(QXmlStreamReader* xml_def);
-    void elaborateEdge(D_graph* graph_rep);
-    inline void setPropsDataType(const PIDataType* data_type = 0) {PConcreteInstance::setPropsDataType(path.dst.pin ? NULL : path.dst.pin->properties());};
+    int elaborateEdge(D_graph* graph_rep);
+    inline void setPropsDataType(const PIDataType* data_type = 0) {PConcreteInstance::setPropsDataType(path.dst.pin ? path.dst.pin->properties() : NULL);};
 
 private:
 
@@ -52,6 +52,7 @@ private:
         unsigned int opin_i;
     } path_index;
 
+    static const unsigned int INVALID_INDEX = 0xFFFFFFFF;
     D_graph* containing_graph;
     enum vld_elem_types {OTHER, STATE};
     QHash<QString, vld_elem_types> valid_elements;

--- a/Source/Parser/pigraphinstance.cpp
+++ b/Source/Parser/pigraphinstance.cpp
@@ -141,6 +141,7 @@ P_task* PIGraphInstance::elaborateGraphInstance(OrchBase* orch_root)
              PDeviceInstance* devInstance = static_cast<PDeviceInstance*>(subObject(DEVINSTS, dev_inst));
              if (!devInstance->deviceType()) devInstance->setDeviceType(); // retrofit the device type if needed
              P_device* device = devInstance->elaborateDeviceInstance(graph_instance->pD);
+             if (device->pP_devtyp == NULL) orch_root->Post(114,device->Name());
              device->idx = static_cast<unsigned>(dev_inst);
              graph_instance->pD->G.InsertNode(static_cast<unsigned>(dev_inst), device);
          }
@@ -157,7 +158,10 @@ P_task* PIGraphInstance::elaborateGraphInstance(OrchBase* orch_root)
          }
          // and then add all the edge instances
          for (QVector<PIGraphObject*>::iterator edge = beginSubObjects(EDGEINSTS); edge < endSubObjects(EDGEINSTS); edge++)
-             static_cast<PEdgeInstance*>(*edge)->elaborateEdge(graph_instance->pD);
+         {
+             int edgeFailure = static_cast<PEdgeInstance*>(*edge)->elaborateEdge(graph_instance->pD);
+             if (edgeFailure) orch_root->Post(112+edgeFailure,edgeFailure == 3 ? (*edge)->name().toStdString() : graph_instance->Name());
+         }
          graph_instance->PoL.IsPoL = false; // set the flag to indicate non-proof-of-life
       }
       return graph_instance;


### PR DESCRIPTION
A bug in the PEdgeInstance object meant edges with bad device types or pins would crash. In addition, the bug would cause edge properties and state to take on default values, even if properties or state existed in the edge instance, if the device and pin types were fine. Fixed this, added some messages warning the user if they have a bad device type or pin type. Note that the Qt Creator config has also been updated to reflect all the changes in Orchestrator. 

Tested with several variants of bad files and with some good ones (including the standard heat plate example) and all is well - no crashes, informative error messages when something is awry.