### PR TITLE
Fix #125: Modify pdigraph for consistent behaviour

### DIFF
--- a/Generics/pdigraph.tpp
+++ b/Generics/pdigraph.tpp
@@ -256,10 +256,12 @@ PDIGRAPH_ bool  _PDIGRAPH::FindArcs(const NKT & n_k,const PKT & p_k,
                                    vector<AKT> & vI,vector<AKT> & vO)
 // Given a node and a pin key, return any/all arc keys
 {
-if (FindNode(n_k)==0) return false;    // Node not there
-if (FindPin(n_k,p_k)==0) return false; // Pin not there
 vI.clear();
 vO.clear();
+
+if (FindNode(n_k)==0) return false;    // Node not there
+if (FindPin(n_k,p_k)==0) return false; // Pin not there
+
                                        // Walk right there...
 pair<TPp_it,TPp_it> pi = index_n[n_k].fano.equal_range(p_k);
 for(typename multimap<PKT,pin>::iterator i=pi.first;i!=pi.second;i++)


### PR DESCRIPTION
This PR changes the order of operations in `_PDIGRAPH::FindArcs` on line 255 of `pdigraph.tpp` so that the arrays are cleared before checking if the pin/node exist. This is consistent with `_PDIGRAPH::FindArcs` on line 279 and gives a more expected and correct behaviour.

Discussed with @mvousden and ADB