### PR TITLE
Fix double-deletion of engine on invalid D3 file under certain conditions.

### DIFF
--- a/Source/OrchBase/HardwareFileReader/HardwareFileReaderCore.cpp
+++ b/Source/OrchBase/HardwareFileReader/HardwareFileReaderCore.cpp
@@ -113,15 +113,7 @@ void HardwareFileReader::populate_hardware_model(P_engine* engine)
     /* Only dialect 1 and 3 for now (get_dialect errors if the dialect is not 1
      * or 3). */
     unsigned dialect;
-    try
-    {
-        dialect = get_dialect();
-    }
-    catch (HardwareSemanticException &e)
-    {
-        delete engine;
-        throw;
-    }
+    dialect = get_dialect();
 
     if (dialect == 1)
     {

--- a/Source/OrchBase/HardwareFileReader/HardwareFileReaderDialect3.cpp
+++ b/Source/OrchBase/HardwareFileReader/HardwareFileReaderDialect3.cpp
@@ -13,7 +13,6 @@
  * - engine: Partially-populated unsafe engine. */
 void HardwareFileReader::d3_catastrophic_failure(P_engine* engine)
 {
-    delete engine;
     std::string allErrors;
     construct_error_output_string(&allErrors);
 

--- a/Source/OrchBase/Placement.cpp
+++ b/Source/OrchBase/Placement.cpp
@@ -12,7 +12,7 @@ Placement::Placement(OrchBase * _p):iterator(0),par(_p),pCon(0),pD_graph(0)
 
 Placement::~Placement()
 {
-    if (iterator == 0) delete iterator;
+    if (iterator != 0) delete iterator;
 }
 
 //------------------------------------------------------------------------------

--- a/Tests/StaticResources/Dialect3/Invalid/invalid_dialect_3_invalid_variable_key.uif
+++ b/Tests/StaticResources/Dialect3/Invalid/invalid_dialect_3_invalid_variable_key.uif
@@ -1,0 +1,55 @@
+// A representation of GMB's MPI cluster. Note the bizarre thread-core relationship
+
+[header("GMB_MPI")]
++author="Mark Vousden"
++dialect=3
++datetime=20200402161500
++version="0.4.0"
++file="gmb_mpi.uif"
+
+// Only the core address meaningfully contributes to the address - there's only
+// one of everything else.
+[packet_address_format]
++box=1  // The box address component is not used.
++board=1
++mailbox=1
++core=28
++thread=0
+
+// All items are of the same type.
+[default_types]
++box_type="CommonBox"
++board_type="CommonBoard"
++mailbox_type="CommonMbox"
+
+[engine_box]
+MPI(addr(0),boards(B00),hostname(gmbmpicluster))
++external_box_cost=0
+
+[engine_board]
+(0,0):MPI(board(B00))
++board_board_cost=0
+
+[box(CommonBox)]
++box_board_cost=0
++supervisor_memory=10240
+
+[board(CommonBoard)]
+(0,0):M00(addr(0))
++board_mailbox_cost=0
++supervisor_memory=0
++mailbox_mailbox_cost=0
++dram=0
+
+[mailbox(CommonMbox)]
++cores=60
++mailbox_core_cost=0
++core_core_cost=0
++core_addr_offset=1
+
+[core]
++threads=1
++instruction_memory=0
++data_memory=0
++core_thread_cost=0
++thread_thread_cost=0

--- a/Tests/StaticResources/Dialect3/Valid/valid_dialect_3_one_thread_per_core.uif
+++ b/Tests/StaticResources/Dialect3/Valid/valid_dialect_3_one_thread_per_core.uif
@@ -1,0 +1,54 @@
+// A representation of GMB's MPI cluster. Note the bizarre thread-core relationship
+
+[header("GMB_MPI")]
++author="Mark Vousden"
++dialect=3
++datetime=20200402161500
++version="0.4.0"
++file="gmb_mpi.uif"
+
+// Only the core address meaningfully contributes to the address - there's only
+// one of everything else.
+[packet_address_format]
++box=1  // The box address component is not used.
++board=1
++mailbox=1
++core=27
++thread=1
+
+// All items are of the same type.
+[default_types]
++box_type="CommonBox"
++board_type="CommonBoard"
++mailbox_type="CommonMbox"
+
+[engine_box]
+MPI(addr(0),boards(B00),hostname(byron))
++external_box_cost=0
+
+[engine_board]
+(0,0):MPI(board(B00))
++board_board_cost=0
+
+[box(CommonBox)]
++box_board_cost=0
++supervisor_memory=10240
+
+[board(CommonBoard)]
+(0,0):M00(addr(0))
++board_mailbox_cost=0
++supervisor_memory=0
++mailbox_mailbox_cost=0 // Relative to box::board_board_cost
++dram=4096  // MiB, two DDR3 DRAM boards.
+
+[mailbox(CommonMbox)]
++cores=60
++mailbox_core_cost=0
++core_core_cost=0
+
+[core]
++threads=1
++instruction_memory=0
++data_memory=0
++core_thread_cost=0
++thread_thread_cost=0

--- a/Tests/TestDialect1Reader.cpp
+++ b/Tests/TestDialect1Reader.cpp
@@ -25,6 +25,7 @@ TEST_CASE("A file with multiple identical valid sections raise a semantics error
     reader.load_file("../Tests/StaticResources/Dialect1/duplicate_section_invalid.uif");
     REQUIRE_THROWS_AS(reader.populate_hardware_model(engine),
                       HardwareSemanticException&);
+    delete engine;
 }
 
 TEST_CASE("A file with a missing section raises a semantics error", "[Reader]")
@@ -34,6 +35,7 @@ TEST_CASE("A file with a missing section raises a semantics error", "[Reader]")
     reader.load_file("../Tests/StaticResources/Dialect1/missing_section_invalid.uif");
     REQUIRE_THROWS_AS(reader.populate_hardware_model(engine),
                       HardwareSemanticException&);
+    delete engine;
 }
 
 TEST_CASE("A file with an invalid section raises a semantics error", "[Reader]")
@@ -43,4 +45,5 @@ TEST_CASE("A file with an invalid section raises a semantics error", "[Reader]")
     reader.load_file("../Tests/StaticResources/Dialect1/invalid_section.uif");
     REQUIRE_THROWS_AS(reader.populate_hardware_model(engine),
                       HardwareSemanticException&);
+    delete engine;
 }

--- a/Tests/TestDialect3Reader.cpp
+++ b/Tests/TestDialect3Reader.cpp
@@ -104,11 +104,7 @@ TEST_CASE("Test each semantically-invalid case in turn", "[Reader]")
         REQUIRE_THROWS_AS(reader->populate_hardware_model(engine),
                           HardwareSemanticException&);
 
-        /* Don't need to delete the engine - the reader is responsible for
-         * doing that on failure. If a bug has been introduced that causes the
-         * reader not to clean up after itself, Valgrind will find it.
-         *
-         * We do need to delete the reader at the end of the loop though. */
+        delete engine;
         delete reader;
     }
 }

--- a/Tests/TestDialect3Reader.cpp
+++ b/Tests/TestDialect3Reader.cpp
@@ -15,6 +15,7 @@
 std::vector<std::string> semanticallyValidInputs = {
     "8_box.uif",
     "valid_dialect_3_mismatched_name.uif",
+    "valid_dialect_3_one_thread_per_core.uif",
     "valid_dialect_3_some_types_in_sections.uif",
     "valid_dialect_3_types_everywhere.uif",
     "valid_dialect_3.uif"
@@ -29,6 +30,7 @@ std::vector<std::string> semanticallyInvalidInputs = {
     "invalid_dialect_3_empty.uif",
     "invalid_dialect_3_floating_dram.uif",
     "invalid_dialect_3_invalid_character_in_type.uif",
+    "invalid_dialect_3_invalid_variable_key.uif",
     "invalid_dialect_3_missing_board_type.uif",
     "invalid_dialect_3_missing_box_type.uif",
     "invalid_dialect_3_missing_cost.uif",

--- a/Tests/TestHardwareFileReader.cpp
+++ b/Tests/TestHardwareFileReader.cpp
@@ -82,6 +82,7 @@ TEST_CASE("Test each invalid dialect example case in turn", "[Reader]")
         REQUIRE_THROWS_AS(reader->populate_hardware_model(engine),
                           HardwareSemanticException&);
 
+        delete engine;
         delete reader;
     }
 }


### PR DESCRIPTION
Resolves #147.

In short, the problem was that both the reader and OrchBase were trying to free memory used by the Engine, when it is OrchBase's responsibility as the caller.

While here, I also fixed an issue with the old placement destructor.