### PR TITLE
Fix a bad memory access attempt in the Softswitch during initialisation

### DIFF
--- a/Source/Softswitch/src/softswitch_common.cpp
+++ b/Source/Softswitch/src/softswitch_common.cpp
@@ -72,7 +72,7 @@ void softswitch_barrier(ThreadCtxt_t* ThreadContext)
     hdr->pinAddr = tinselId();          // usurp Pin Addr for the source HW addr
 
     // and then issue the packet indicating this thread's startup is complete.
-    tinselSetLen(p_hdr_size());
+    tinselSetLen((p_hdr_size() - 1) >> TinselLogBytesPerFlit);
     tinselSend(tinselHostId(), send_buf);
     
     // second phase of barrier: wait for the supervisor's response


### PR DESCRIPTION
This is a small PR to address a memory access issue identified with the MPI backend - basically it was trying to access memory it had no right trying to access during the barrier because we were setting the packet length to be too large. Tinsel appears to have been saving us from ourselves by silently setting a max packet limit, but that is obviously not desirable.

The call to TinselSetLen() in the barrier now replicates the call(s) elsewhere in the Softswitch.

This has been tested with a few different plates on Ayres and on my nasty MPI backend.