### PR TITLE
Supervisor API

### DIFF
--- a/Build/gcc/Makefile
+++ b/Build/gcc/Makefile
@@ -216,7 +216,8 @@ COMPOSER_ENV_DEPENDENCIES := \
 	$(COMPOSER_ENV_DIR)/Tinsel \
 	$(COMPOSER_ENV_DIR)/Makefile \
 	$(COMPOSER_ENV_DIR)/Supervisor.cpp \
-	$(COMPOSER_ENV_DIR)/Supervisor.h
+	$(COMPOSER_ENV_DIR)/Supervisor.h \
+	$(COMPOSER_ENV_DIR)/SupervisorApi.h
 
 composer_environment: $(COMPOSER_ENV_DEPENDENCIES)
 
@@ -239,6 +240,10 @@ $(COMPOSER_ENV_DIR)/Tinsel:
 $(COMPOSER_ENV_DIR)/Makefile:
 	$(MKDIR) "$(dir $@)"
 	ln --force --symbolic "$(abspath $(SOURCE_DIR)/Softswitch/Makefile)" "$@"
+
+$(COMPOSER_ENV_DIR)/SupervisorApi.h:
+	ln --force --symbolic \
+	"$(abspath $(SOURCE_DIR)/Supervisor/SupervisorApi$(suffix $@))" "$@"
 
 $(COMPOSER_ENV_DIR)/Supervisor.cpp $(COMPOSER_ENV_DIR)/Supervisor.h:
 	$(MKDIR) "$(dir $@)"

--- a/Build/gcc/Makefile
+++ b/Build/gcc/Makefile
@@ -217,7 +217,8 @@ COMPOSER_ENV_DEPENDENCIES := \
 	$(COMPOSER_ENV_DIR)/Makefile \
 	$(COMPOSER_ENV_DIR)/Supervisor.cpp \
 	$(COMPOSER_ENV_DIR)/Supervisor.h \
-	$(COMPOSER_ENV_DIR)/SupervisorApi.h
+	$(COMPOSER_ENV_DIR)/SupervisorApi.h \
+	$(COMPOSER_ENV_DIR)/SupervisorApiEntrypoints.h
 
 composer_environment: $(COMPOSER_ENV_DEPENDENCIES)
 
@@ -244,6 +245,10 @@ $(COMPOSER_ENV_DIR)/Makefile:
 $(COMPOSER_ENV_DIR)/SupervisorApi.h:
 	ln --force --symbolic \
 	"$(abspath $(SOURCE_DIR)/Supervisor/SupervisorApi$(suffix $@))" "$@"
+
+$(COMPOSER_ENV_DIR)/SupervisorApiEntrypoints.h:
+	ln --force --symbolic \
+	"$(abspath $(SOURCE_DIR)/Supervisor/SupervisorApiEntrypoints$(suffix $@))" "$@"
 
 $(COMPOSER_ENV_DIR)/Supervisor.cpp $(COMPOSER_ENV_DIR)/Supervisor.h:
 	$(MKDIR) "$(dir $@)"

--- a/Build/gcc/Makefile.executable_prerequisites
+++ b/Build/gcc/Makefile.executable_prerequisites
@@ -250,7 +250,7 @@ MOTHERSHIP_SOURCES = $(SOURCE_DIR)/Mothership/MothershipMain.cpp \
                      $(SOURCE_DIR)/Mothership/PacketHandlers.cpp \
                      $(SOURCE_DIR)/Mothership/SuperDB.cpp \
                      $(SOURCE_DIR)/Mothership/SuperHolder.cpp \
-                     $(SOURCE_DIR)/Mothership/SuperHolder.cpp \
+                     $(SOURCE_DIR)/Mothership/SupervisorApiProvisioning.cpp \
                      $(SOURCE_DIR)/Mothership/ThreadComms.cpp \
                      $(SOURCE_DIR)/Mothership/ThreadLogic.cpp \
 

--- a/Config/Orchestrator.ocfg
+++ b/Config/Orchestrator.ocfg
@@ -10,8 +10,8 @@
 // All pretty arbitrary; just copied in and stored
 name        = OrchestratorConfiguration
 author      = "MLV and GMB"
-date        = "2020-10-06"
-version     = "0.0.5"
+date        = "2021-01-17"
+version     = "0.0.6"
 
 // All these may be overridden by the console "path" command
 [default_paths]
@@ -28,6 +28,9 @@ ulog = "../Output/Microlog/"
 place = "../Output/Placement/"
 // Location for files transferred to Motherships. Relative to home.
 remote_mship = ".orchestrator/app_binaries/"
+// Location for user output directories to be created by Motherships. Relative
+// to home.
+remote_outdir = ".orchestrator/app_output/"
 // Staged source files and binaries for applications
 stage = "../Output/Composer/"
 // Application binary files for execution

--- a/Config/OrchestratorMessages.ocfg
+++ b/Config/OrchestratorMessages.ocfg
@@ -110,6 +110,7 @@
 180(W) : "Ignoring clauses in 'dump /plac' command - dumping all files to '%s'."
 181(W) : "No application graph instances have been placed. Not dumping anything."
 182(I) : "Placement information dumped to '%s'."
+183(E) : "Received MPI message with unrecognised key '%s'. Source rank: %s. Destination rank: %s.
 
 201(E) : "... failed %s with %s errors in %s msecs"
 202(I) : "Task: %s file: %s returns %s errors."

--- a/Config/OrchestratorMessages.ocfg
+++ b/Config/OrchestratorMessages.ocfg
@@ -204,6 +204,7 @@
 525(E) : "Mothership: Error provisioning supervisor for application '%s': 'could not find a loaded supervisor for this application."
 526(I) : "Mothership: Supervisor for application '%s' has requested it to be stopped."
 527(I) : "Mothership: Message from supervisor for application '%s': %s
+528(E) : "Error creating directory '%s' for application '%s': %s"
 
 582(I) : "Mothership: Received a message containing packets for a supervisor device for application '%s' that is not running (it may be in the process of stopping). Ignoring these packets."
 583(I) : "Mothership: Initialising supervisor device for application '%s'."

--- a/Config/OrchestratorMessages.ocfg
+++ b/Config/OrchestratorMessages.ocfg
@@ -203,6 +203,7 @@
 524(E) : "Mothership: Application '%s' received more distribution messages than expected (%s). Marking application as BROKEN (which may cause other errors)."
 525(E) : "Mothership: Error provisioning supervisor for application '%s': 'could not find a loaded supervisor for this application."
 526(I) : "Mothership: Supervisor for application '%s' has requested it to be stopped."
+527(I) : "Mothership: Message from supervisor for application '%s': %s
 
 582(I) : "Mothership: Received a message containing packets for a supervisor device for application '%s' that is not running (it may be in the process of stopping). Ignoring these packets."
 583(I) : "Mothership: Initialising supervisor device for application '%s'."

--- a/Config/OrchestratorMessages.ocfg
+++ b/Config/OrchestratorMessages.ocfg
@@ -201,6 +201,7 @@
 522(E) : "Mothership: Error decoding MPI message with key '0x%s': Expected a vector of uint32_t values in field %s. Ignoring message."
 523(E) : "Mothership: Supervisor for application '%s' failed to initialise correctly. Marking application as BROKEN (which may cause other errors)."
 524(E) : "Mothership: Application '%s' received more distribution messages than expected (%s). Marking application as BROKEN (which may cause other errors)."
+525(E) : "Mothership: Error provisioning supervisor for application '%s': 'could not find a loaded supervisor for this application."
 
 582(I) : "Mothership: Received a message containing packets for a supervisor device for application '%s' that is not running (it may be in the process of stopping). Ignoring these packets."
 583(I) : "Mothership: Initialising supervisor device for application '%s'."

--- a/Config/OrchestratorMessages.ocfg
+++ b/Config/OrchestratorMessages.ocfg
@@ -202,6 +202,7 @@
 523(E) : "Mothership: Supervisor for application '%s' failed to initialise correctly. Marking application as BROKEN (which may cause other errors)."
 524(E) : "Mothership: Application '%s' received more distribution messages than expected (%s). Marking application as BROKEN (which may cause other errors)."
 525(E) : "Mothership: Error provisioning supervisor for application '%s': 'could not find a loaded supervisor for this application."
+526(I) : "Mothership: Supervisor for application '%s' has requested it to be stopped."
 
 582(I) : "Mothership: Received a message containing packets for a supervisor device for application '%s' that is not running (it may be in the process of stopping). Ignoring these packets."
 583(I) : "Mothership: Initialising supervisor device for application '%s'."

--- a/Source/Common/Pglobals.cpp
+++ b/Source/Common/Pglobals.cpp
@@ -18,6 +18,7 @@ const byte Q::BEND    = 0x0e;
 const byte Q::PKTS    = 0x0f;
 const byte Q::DUMP    = 0x10;
 const byte Q::MSHP    = 0x11;
+const byte Q::PATH    = 0x12;
 // Level 1 subkeys
 const byte Q::PING    = 0x40;
 const byte Q::POST    = 0x41;

--- a/Source/Common/Pglobals.h
+++ b/Source/Common/Pglobals.h
@@ -95,6 +95,7 @@ CMND |STOP |-    |-    | (0:string)Application name
 BEND |CNC  |-    |-    | (0:P_Pkt_t)Packet
 BEND |SUPR |-    |-    | (0:string)Application name
                          (1:P_Pkt_t)Packet
+PATH |-    |-    |-    | (0:string)Output path base
 PKTS |-    |-    |-    | (0:vector<pair<uint32_t, P_Pkt_t> >)Packets
 DUMP |-    |-    |-    | (0:string)Path to write the dump to
 

--- a/Source/Common/Pglobals.h
+++ b/Source/Common/Pglobals.h
@@ -58,6 +58,7 @@ MSHP |ACK  |DEFD |-    | (0:string)Application name
 MSHP |ACK  |LOAD |-    | (0:string)Application name
 MSHP |ACK  |RUN  |-    | (0:string)Application name
 MSHP |ACK  |STOP |-    | (0:string)Application name
+MSHP |REQ  |STOP |-    | (0:string)Application name
 
 LogServer
 ---------

--- a/Source/Common/Pglobals.h
+++ b/Source/Common/Pglobals.h
@@ -126,6 +126,7 @@ static const byte BEND;
 static const byte PKTS;
 static const byte DUMP;
 static const byte MSHP;
+static const byte PATH;
 // Level 1 subkeys
 static const byte PING;
 static const byte POST;

--- a/Source/Mothership/AppTransitions.cpp
+++ b/Source/Mothership/AppTransitions.cpp
@@ -156,8 +156,7 @@ void Mothership::stop_application(AppInfo* app)
     if(!provision_supervisor_api(appName))
     {
         Post(525, appName);
-        appInfo->state = BROKEN;
-        return 0;
+        app->state = BROKEN;
     }
 }
 

--- a/Source/Mothership/AppTransitions.cpp
+++ b/Source/Mothership/AppTransitions.cpp
@@ -151,6 +151,14 @@ void Mothership::stop_application(AppInfo* app)
         Post(503, appName, errorMessage);
         app->state = BROKEN;
     }
+
+    /* On (re)loading the supervisor, provision its API. */
+    if(!provision_supervisor_api(appName))
+    {
+        Post(525, appName);
+        appInfo->state = BROKEN;
+        return 0;
+    }
 }
 
 /* Sends a CNC packet with a given opcode to each thread in an application. */

--- a/Source/Mothership/MPIHandlers.cpp
+++ b/Source/Mothership/MPIHandlers.cpp
@@ -248,6 +248,14 @@ unsigned Mothership::handle_msg_app_supd(PMsg_p* message)
         return 0;
     }
 
+    /* On loading the supervisor, provision its API. */
+    if(!provision_supervisor_api(appName))
+    {
+        Post(525, appName);
+        appInfo->state = BROKEN;
+        return 0;
+    }
+
     /* Otherwise, increment the distribution message count. If the distribution
      * message count is too high, shout loudly, and break the application. */
     if (!appInfo->increment_dist_count_current())

--- a/Source/Mothership/MPIHandlers.cpp
+++ b/Source/Mothership/MPIHandlers.cpp
@@ -455,6 +455,25 @@ unsigned Mothership::handle_msg_bend_supr(PMsg_p* message)
     return 0;
 }
 
+unsigned Mothership::handle_msg_path(PMsg_p* message)
+{
+    /* Pull message contents. */
+    std::string userOutRoot;
+    if (!decode_string_message(message, &userOutRoot))
+    {
+        debug_post(597, 3, "Q::PATH", hex2str(message->Key()).c_str(),
+                   "Failed to decode.");
+        return 0;
+    }
+
+    debug_post(597, 3, "Q::PATH", hex2str(message->Key()).c_str(),
+               dformat("userOutRoot=%s", userOutRoot.c_str()).c_str());
+
+    /* Out we go. */
+    userOutDir = userOutRoot;
+    return 0;
+}
+
 unsigned Mothership::handle_msg_pkts(PMsg_p* message)
 {
     /* Pull message contents. */

--- a/Source/Mothership/Mothership.cpp
+++ b/Source/Mothership/Mothership.cpp
@@ -5,7 +5,8 @@ Mothership::Mothership(int argc, char** argv):
     CommonBase(argc, argv, std::string(csMOTHERSHIPproc),
                std::string(__FILE__)),
     backend(PNULL),
-    threading(ThreadComms(this))
+    threading(ThreadComms(this)),
+    userOutDir(".orchestrator/app_output/") /* Sensible default */
 {
     try
     {

--- a/Source/Mothership/Mothership.cpp
+++ b/Source/Mothership/Mothership.cpp
@@ -194,6 +194,7 @@ void Mothership::setup_mpi_hooks()
     FnMap[PMsg_p::KEY(Q::CMND,Q::STOP)] = &Mothership::handle_msg_cnc;
     FnMap[PMsg_p::KEY(Q::BEND,Q::CNC)] = &Mothership::handle_msg_cnc;
     FnMap[PMsg_p::KEY(Q::BEND,Q::SUPR)] = &Mothership::handle_msg_app;
+    FnMap[PMsg_p::KEY(Q::PATH)] = &Mothership::handle_msg_path;
     FnMap[PMsg_p::KEY(Q::PKTS)] = &Mothership::handle_msg_app;
     FnMap[PMsg_p::KEY(Q::DUMP)] = &Mothership::handle_msg_cnc;
 }

--- a/Source/Mothership/Mothership.h
+++ b/Source/Mothership/Mothership.h
@@ -113,6 +113,10 @@ private:
     bool decode_unsigned_message(PMsg_p* message, unsigned* result,
                                  unsigned index=0);
 
+    /* Methods for provisioning the API for Supervisors. */
+    bool provision_supervisor_api(std::string appName);
+    void supervisor_api_stop_application(std::string appName);
+
     /* Supervisor spinning (virtual from CommonBase). */
     void OnIdle();
 };

--- a/Source/Mothership/Mothership.h
+++ b/Source/Mothership/Mothership.h
@@ -40,6 +40,9 @@ public:
     SuperDB superdb;
     ThreadComms threading;
 
+    /* Root directory for supervisor output, relative to home. */
+    std::string userOutDir;
+
     /* Methods for transitioning applications through states, triggered by
      * different Q::APP message keys. */
     void initialise_application(AppInfo*);
@@ -57,6 +60,7 @@ public:
     unsigned handle_msg_cmnd_stop(PMsg_p* message);
     unsigned handle_msg_bend_cnc(PMsg_p* message);
     unsigned handle_msg_bend_supr(PMsg_p* message);
+    unsigned handle_msg_path(PMsg_p* message);
     unsigned handle_msg_pkts(PMsg_p* message);
     unsigned handle_msg_dump(PMsg_p* message);
 

--- a/Source/Mothership/SuperDB.cpp
+++ b/Source/Mothership/SuperDB.cpp
@@ -42,6 +42,15 @@ SuperHolder* SuperDB::get_next_idle(std::string& name)
     return nextIdle->second;
 }
 
+/* Retrieves a reference to the api-communications object used by the
+ * supervisor shared object, so it can be populated or modified. Note the lack
+ * of locking. */
+SupervisorApi* SuperDB::get_supervisor_api(std::string appName)
+{
+    SuperIt superFinder = supervisors.find(appName); \
+    if (superFinder == supervisors.end()) return PNULL;
+    return (*(superFinder->second->getApi))();
+}
 
 /* Loads a supervisor into the database, returning true on success and false on
  * failure. If there is a failure, errorMessage is written with the contents of
@@ -61,7 +70,7 @@ bool SuperDB::load_supervisor(std::string appName, std::string path,
     }
 
     /* Otherwise, load up. */
-    supervisors[appName] = new SuperHolder(path);
+    supervisors[appName] = new SuperHolder(path, appName);
     nextIdle = supervisors.begin();
 
     /* Check for errors as per the specification... */

--- a/Source/Mothership/SuperDB.h
+++ b/Source/Mothership/SuperDB.h
@@ -40,9 +40,10 @@ public:
     SuperDB();
     ~SuperDB();
 
-    SuperHolder* get_next_idle(std::string& name);
     int call_supervisor(std::string appName, PMsg_p* inputMessage,
                         PMsg_p* outputMessage);
+    SuperHolder* get_next_idle(std::string& name);
+    SupervisorApi* get_supervisor_api(std::string appName);
     bool load_supervisor(std::string appName, std::string path,
                          std::string* errorMessage);
     bool reload_supervisor(std::string appName, std::string* errorMessage);

--- a/Source/Mothership/SuperHolder.cpp
+++ b/Source/Mothership/SuperHolder.cpp
@@ -51,7 +51,6 @@ bool SuperHolder::are_all_hooks_loaded()
     return not (call == NULL or
                 exit == NULL or
                 idle == NULL or
-                implicitCall == NULL or
                 init == NULL);
 }
 

--- a/Source/Mothership/SuperHolder.cpp
+++ b/Source/Mothership/SuperHolder.cpp
@@ -3,7 +3,7 @@
 /* Here we load the shared objects! It is down to the creator to verify the
  * success of the loading process (i.e. by checking (error), and by calling
  * dlerror to obtain an error message). */
-SuperHolder::SuperHolder(std::string path):
+SuperHolder::SuperHolder(std::string path, std::string appName):
     path(path)
 {
     pthread_mutex_init(&lock, NULL);
@@ -27,7 +27,13 @@ SuperHolder::SuperHolder(std::string path):
     if (idle == NULL) error = true;
     init = reinterpret_cast<int (*)()>(dlsym(so, "SupervisorInit"));
     if (init == NULL) error = true;
-    /* We out, yo */
+
+    /* Bind the method that allows the Mothership to get this Supervisor's API
+     * object, if possible (before the Mothership provisions it - we want to
+     * ensure it is loadable). */
+    getApi = reinterpret_cast<SupervisorApi* (*)()>
+        (dlsym(so, "GetSupervisorApi"));
+    if (getApi == NULL) error = true;
 }
 
 /* And here we close them. */

--- a/Source/Mothership/SuperHolder.h
+++ b/Source/Mothership/SuperHolder.h
@@ -27,7 +27,6 @@ public:
     SupervisorApi* (*getApi)();
     int (*idle)();
     int (*init)();
-    int (*implicitCall)(PMsg_p*, PMsg_p*);
 
 private:
     void* so;

--- a/Source/Mothership/SuperHolder.h
+++ b/Source/Mothership/SuperHolder.h
@@ -9,19 +9,22 @@
 #include <fstream>
 
 #include "PMsg_p.hpp"
+#include "SupervisorApi.h"
 
 class SuperHolder
 {
 public:
-    SuperHolder(std::string path);
+    SuperHolder(std::string path, std::string appName);
     ~SuperHolder();
     std::string path;
     bool error;
     pthread_mutex_t lock;
+    SupervisorApi* api;
     bool are_all_hooks_loaded();
     void dump(std::ofstream*);
     int (*call)(PMsg_p*, PMsg_p*);
     int (*exit)();
+    SupervisorApi* (*getApi)();
     int (*idle)();
     int (*init)();
     int (*implicitCall)(PMsg_p*, PMsg_p*);

--- a/Source/Mothership/SupervisorApiProvisioning.cpp
+++ b/Source/Mothership/SupervisorApiProvisioning.cpp
@@ -27,6 +27,87 @@ namespace SuperAPIBindings {
         mship->Post(526, appName);
         mship->queue_mpi_message(&message);
     }
+
+    /* Creates a specific, guaranteed-empty output directory, with an optional
+     * suffix. Directories are of the form:
+     *
+     *   /home/$USER/<REMOTE_OUTDIR>/<APPNAME>/<DATETIME_ISO8601><SUFFIX>
+     *
+     * where <REMOTE_OUTDIR> is defined in the Orchestrator configuration file,
+     * and <APPNAME> is the combined application-graphinstance name with the
+     * colons substituted out for underscores. Directory (and parents) are
+     * created if they don't exist. Uses GNU-isms and Linux-isms.
+     *
+     * The directory may change between successive calls from the same
+     * supervisor device - considering storing it in Supervisor state (in your
+     * application) if you want it to remain constant.
+     *
+     * Returns the path to the directory on success, and an empty string on
+     * failure. Also posts on failure. */
+    std::string get_output_directory(Mothership* mship, std::string appName,
+                                     std::string suffix)
+    {
+        /* Remove :s from the application name. */
+        std::string sanitisedAppName = appName;
+        std::replace(sanitisedAppName.begin(), sanitisedAppName.end(),
+                     ':', '_');
+
+        /* Get datetime */
+        time_t native;
+        time(&native);
+        char time[sizeof "YYYY_MM_DDTHH_MM_SS"];
+        strftime(time, sizeof time, "%Y_%m_%dT%H_%M_%S", localtime(&native));
+
+        /* Construct path (no filesystem library). */
+        std::string userDir = \
+            std::string(getenv("HOME")) + "/" +
+            mship->userOutDir + "/" +
+            sanitisedAppName + "/" +
+            time + suffix;
+
+        /* Attempt to make it (fairly safe to assume it doesn't already
+         * exist, given the timestamp... NFS eat your heart out). */
+        if(system((MAKEDIR + "--parents " + userDir).c_str()))
+        {
+            mship->Post(528, userDir, appName,
+                        OSFixes::getSysErrorString(errno));
+            return "";
+        }
+
+        /* Now that we have it, attempt to write to a file within it. */
+        std::ofstream testFile;
+        std::string testFileName = "test_file.txt";
+        testFile.open((userDir + "/" + testFileName).c_str());
+        if (testFile.fail())  /* Best efforts */
+        {
+            mship->Post(528, userDir, appName,
+                        "Could not open a file for writing in the directory "
+                        "(check directory permissions and ownership).");
+            if(system((REMOVEDIR + userDir + "/" + testFileName).c_str()))
+            {
+                mship->Post(528, userDir, appName,
+                            "While cleaning up from the previous error, could "
+                            "not remove the directory.");
+            }
+            return "";
+        }
+
+        testFile << "This file is transient. If it persists, speak to an "
+            "Orchestrator developer." << std::endl;
+        testFile.close();
+
+        /* Remove the transient file. */
+        if(system((REMOVEDIR + userDir + "/" + testFileName).c_str()))
+        {
+            mship->Post(528, userDir, appName,
+                        "Could not remove a file opened as a test "
+                        "(check directory permissions and ownership).");
+
+            return "";
+        }
+
+        return userDir;
+    }
 }
 
 /* Define the supervisor's API functions and variables. Returns true on
@@ -37,6 +118,7 @@ bool Mothership::provision_supervisor_api(std::string appName)
     if (api == PNULL) return false;
     api->mship = this;
     api->appName = appName;
+    api->get_output_directory = &SuperAPIBindings::get_output_directory;
     api->post = &SuperAPIBindings::post;
     api->stop_application = &SuperAPIBindings::stop_application;
     return true;

--- a/Source/Mothership/SupervisorApiProvisioning.cpp
+++ b/Source/Mothership/SupervisorApiProvisioning.cpp
@@ -16,7 +16,7 @@ namespace SuperAPIBindings {
         PMsg_p message;
         message.Src(mship->Urank);
         message.Key(Q::MSHP, Q::REQ, Q::STOP);
-        message.Put<std::string>(0, &(appName));
+        message.Put(0, &(appName));
         message.Tgt(mship->pPmap->U.Root);
         mship->Post(526, appName);
         mship->queue_mpi_message(&message);

--- a/Source/Mothership/SupervisorApiProvisioning.cpp
+++ b/Source/Mothership/SupervisorApiProvisioning.cpp
@@ -67,7 +67,7 @@ namespace SuperAPIBindings {
 
         /* Attempt to make it (fairly safe to assume it doesn't already
          * exist, given the timestamp... NFS eat your heart out). */
-        if(system((MAKEDIR + "--parents " + userDir).c_str()))
+        if(system((MAKEDIR + " --parents " + userDir).c_str()))
         {
             mship->Post(528, userDir, appName,
                         OSFixes::getSysErrorString(errno));
@@ -83,7 +83,8 @@ namespace SuperAPIBindings {
             mship->Post(528, userDir, appName,
                         "Could not open a file for writing in the directory "
                         "(check directory permissions and ownership).");
-            if(system((REMOVEDIR + userDir + "/" + testFileName).c_str()))
+            if(system((REMOVEDIR + " " + userDir + "/" +
+                       testFileName).c_str()))
             {
                 mship->Post(528, userDir, appName,
                             "While cleaning up from the previous error, could "
@@ -97,7 +98,7 @@ namespace SuperAPIBindings {
         testFile.close();
 
         /* Remove the transient file. */
-        if(system((REMOVEDIR + userDir + "/" + testFileName).c_str()))
+        if(system((REMOVEDIR + " " + userDir + "/" + testFileName).c_str()))
         {
             mship->Post(528, userDir, appName,
                         "Could not remove a file opened as a test "

--- a/Source/Mothership/SupervisorApiProvisioning.cpp
+++ b/Source/Mothership/SupervisorApiProvisioning.cpp
@@ -15,7 +15,7 @@ namespace SuperAPIBindings {
     {
         PMsg_p message;
         message.Src(mship->Urank);
-        message.Key(Q::MSHP, Q::REQ, Q::RUN);
+        message.Key(Q::MSHP, Q::REQ, Q::STOP);
         message.Put<std::string>(0, &(appName));
         message.Tgt(mship->pPmap->U.Root);
         mship->Post(526, appName);

--- a/Source/Mothership/SupervisorApiProvisioning.cpp
+++ b/Source/Mothership/SupervisorApiProvisioning.cpp
@@ -67,10 +67,12 @@ namespace SuperAPIBindings {
 
         /* Attempt to make it (fairly safe to assume it doesn't already
          * exist, given the timestamp... NFS eat your heart out). */
-        if(system((MAKEDIR + " --parents " + userDir).c_str()))
+        FILE* system = popen((MAKEDIR + " --parents " + userDir
+                              + " 2>/dev/null").c_str(), "w");
+        if(pclose(system) != 0)
         {
             mship->Post(528, userDir, appName,
-                        OSFixes::getSysErrorString(errno));
+                        "Base directory could not be made.");
             return "";
         }
 
@@ -83,8 +85,9 @@ namespace SuperAPIBindings {
             mship->Post(528, userDir, appName,
                         "Could not open a file for writing in the directory "
                         "(check directory permissions and ownership).");
-            if(system((REMOVEDIR + " " + userDir + "/" +
-                       testFileName).c_str()))
+            system = popen((REMOVEDIR + " " + userDir + "/" +
+                            testFileName + " 2>/dev/null").c_str(), "w");
+            if(pclose(system) != 0)
             {
                 mship->Post(528, userDir, appName,
                             "While cleaning up from the previous error, could "
@@ -98,7 +101,9 @@ namespace SuperAPIBindings {
         testFile.close();
 
         /* Remove the transient file. */
-        if(system((REMOVEDIR + " " + userDir + "/" + testFileName).c_str()))
+        system = popen((REMOVEDIR + " " + userDir + "/" +
+                        testFileName + " 2>/dev/null").c_str(), "w");
+        if(pclose(system) != 0)
         {
             mship->Post(528, userDir, appName,
                         "Could not remove a file opened as a test "

--- a/Source/Mothership/SupervisorApiProvisioning.cpp
+++ b/Source/Mothership/SupervisorApiProvisioning.cpp
@@ -10,9 +10,9 @@
 
 namespace SuperAPIBindings {
     /* Posts a logserver message. */
-    void post(Mothership* mship, std::string message)
+    void post(Mothership* mship, std::string appName, std::string message)
     {
-        mship->Post(527, message);
+        mship->Post(527, appName, message);
     }
 
     /* Sends a message to root, requesting that this application be stopped

--- a/Source/Mothership/SupervisorApiProvisioning.cpp
+++ b/Source/Mothership/SupervisorApiProvisioning.cpp
@@ -1,0 +1,30 @@
+/* This source file defines Mothership methods responsible for provisioning the
+ * API objects in supervisors.
+ *
+ * The "master" method is 'provision_supervisor_api', which binds the other
+ * methods to function pointers in the API object. */
+
+#include "Mothership.h"
+
+/* Define the supervisor's API functions and variables. Returns true on
+ * successful load, and false otherwise. */
+bool Mothership::provision_supervisor_api(std::string appName)
+{
+    SupervisorApi* api = superdb.get_supervisor_api(appName);
+    if (api == PNULL) return false;
+    api->appName = appName;
+    api->stop_application = &Mothership::supervisor_api_stop_application;
+    return true;
+}
+
+/* Sends a message to root, requesting that this application be stopped (across
+ * all Motherships) */
+void Mothership::supervisor_api_stop_application(std::string appName)
+{
+    PMsg_p message;
+    message.Src(Urank);
+    message.Key(Q::MSHP, Q::REQ, Q::RUN);
+    message.Put<std::string>(0, &(appName));
+    message.Tgt(pPmap->U.Root);
+    queue_mpi_message(&message);
+}

--- a/Source/Mothership/SupervisorApiProvisioning.cpp
+++ b/Source/Mothership/SupervisorApiProvisioning.cpp
@@ -18,6 +18,7 @@ namespace SuperAPIBindings {
         message.Key(Q::MSHP, Q::REQ, Q::RUN);
         message.Put<std::string>(0, &(appName));
         message.Tgt(mship->pPmap->U.Root);
+        mship->Post(526, appName);
         mship->queue_mpi_message(&message);
     }
 }

--- a/Source/Mothership/SupervisorApiProvisioning.cpp
+++ b/Source/Mothership/SupervisorApiProvisioning.cpp
@@ -9,6 +9,12 @@
 #include "Mothership.h"
 
 namespace SuperAPIBindings {
+    /* Posts a logserver message. */
+    void post(Mothership* mship, std::string message)
+    {
+        mship->Post(527, message);
+    }
+
     /* Sends a message to root, requesting that this application be stopped
      * (across all Motherships) */
     void stop_application(Mothership* mship, std::string appName)
@@ -31,6 +37,7 @@ bool Mothership::provision_supervisor_api(std::string appName)
     if (api == PNULL) return false;
     api->mship = this;
     api->appName = appName;
+    api->post = &SuperAPIBindings::post;
     api->stop_application = &SuperAPIBindings::stop_application;
     return true;
 }

--- a/Source/OrchBase/AppStructures/GraphI_t.cpp
+++ b/Source/OrchBase/AppStructures/GraphI_t.cpp
@@ -124,6 +124,18 @@ fflush(fp);
 
 //------------------------------------------------------------------------------
 
+string GraphI_t::GetCompoundName(bool path)
+// Convenience method to get the name of this graph instance compounded with
+// the name of the app from which it was loaded.
+//
+// Uses a different syntax if the name is to be used to define a path.
+{
+    if (path) return par->Name() + "__" + Name();
+    else return par->Name() + "::" + Name();
+}
+
+//------------------------------------------------------------------------------
+
 DevI_t * GraphI_t::GetDevice(string & rname)
 // Search the graph *by name* for a device.
 // If there isn't one there already, make one.

--- a/Source/OrchBase/AppStructures/GraphI_t.h
+++ b/Source/OrchBase/AppStructures/GraphI_t.h
@@ -25,6 +25,7 @@ public:
 virtual ~            GraphI_t();
 void                 DevicesOfType(DevT_t *,vector<DevI_t *>&);
 void                 Dump(unsigned =0,FILE * = stdout);
+string               GetCompoundName(bool path = false);
 DevI_t *             GetDevice(string &);
 bool                 TLink() { return pT!=0; }
 unsigned             TypeLink();

--- a/Source/OrchBase/Composer.cpp
+++ b/Source/OrchBase/Composer.cpp
@@ -184,7 +184,7 @@ int Composer::generate(GraphI_t* graphI)
             formDevTStrings(builderGraphI, (*devT));
         }
     }
-    
+
     // Cache the file provenance info
     formFileProvenance(builderGraphI);
 
@@ -196,9 +196,9 @@ int Composer::generate(GraphI_t* graphI)
     props_hFName << outputPath << builderGraphI->outputDir;
     props_hFName << "/" << GENERATED_PATH;
     props_hFName << "/GlobalProperties.h";
-    
+
     std::string props_hFNameStr = props_hFName.str();
-    
+
     props_h.open(props_hFNameStr.c_str());
     if(props_h.fail()) // Check that the file opened
     {                 // if it didn't, tell logserver and exit
@@ -209,15 +209,15 @@ int Composer::generate(GraphI_t* graphI)
     writeFileProvenance(props_hFNameStr, builderGraphI, props_h);
     writeGlobalPropsD(graphI, props_h);
     props_h.close();
-    
-    
+
+
     std::stringstream pkt_hFName;
     pkt_hFName << outputPath << builderGraphI->outputDir;
     pkt_hFName << "/" << GENERATED_PATH;
     pkt_hFName << "/MessageFormats.h";
-    
+
     std::string pkt_hFNameStr = pkt_hFName.str();
-    
+
     pkt_h.open(pkt_hFNameStr.c_str());
     if(pkt_h.fail()) // Check that the file opened
     {                 // if it didn't, tell logserver and exit
@@ -566,17 +566,17 @@ int Composer::clean(GraphI_t* graphI)
         //par->Post(817, task_dir, OSFixes::getSysErrorString(errno));
         fprintf(fd,"\tFailed to remove %s\n",taskDir.c_str());
     }
-    
+
     // Cleanup the core Binary paths.
     WALKSET(P_core*,(*(builderGraphI->cores)),coreNode)
     {
         P_core* pCore = (*coreNode);
         pCore->instructionBinary = "";
     }
-    
+
     // Cleanup Supervisor binary path.
     builderGraphI->graphI->pSupI->binPath = "";
-    
+
     builderGraphI->compiled = 0;
     builderGraphI->graphI->built = 0;
     return 0;
@@ -590,7 +590,7 @@ void Composer::formFileProvenance(ComposerGraphI_t* builderGraphI)
 {
     GraphI_t* graphI = builderGraphI->graphI;
     std::stringstream provStr;
-    
+
     //TODO: this should be cached
     provStr << " * Graph Instance XML:\t\t" << graphI->par->filename << "\n";
     provStr << " * Graph:\t\t\t\t\t" << graphI->FullName() << "\n";
@@ -598,7 +598,7 @@ void Composer::formFileProvenance(ComposerGraphI_t* builderGraphI)
     provStr << (graphI->tyId2.empty() ? graphI->tyId : graphI->tyId2) << "\n";
     provStr << " * Platform Definition:\t" << "\n";
     provStr << " * Placement Method:\t\t";
-    
+
     std::map<GraphI_t*, Algorithm*>::iterator pGIter;
     pGIter = placer->placedGraphs.find(graphI);
     if (pGIter == placer->placedGraphs.end())
@@ -606,10 +606,10 @@ void Composer::formFileProvenance(ComposerGraphI_t* builderGraphI)
         provStr << "***UNPLACED***\n";
     }
     else
-    {  
+    {
         provStr << pGIter->second->result.method <<"\n";
     }
-    
+
     builderGraphI->provenanceCache = provStr.str();
 }
 
@@ -624,13 +624,13 @@ void Composer::writeFileProvenance(std::string& fName,
     time(&timeNtv);
     char timeBuf[sizeof "YYYY-MM-DDTHH:MM:SS"];
     strftime(timeBuf,sizeof timeBuf,"%Y_%m_%dT%H_%M_%S",localtime(&timeNtv));
-    
+
     f << "/* " << fName << "\n";
     f << " * Generated at " << timeBuf << "\n";
-    
+
     // Add the cached string
     f << builderGraphI->provenanceCache;
-    
+
     f << " */\n\n";
  }
 
@@ -724,7 +724,7 @@ int Composer::prepareDirectories(ComposerGraphI_t* builderGraphI)
     std::stringstream cpCmd;
 
     cpCmd << SYS_COPY << " ";
-    cpCmd << outputPath << "Supervisor.* ";                     // Source
+    cpCmd << outputPath << "Supervisor* ";                      // Sources
     cpCmd << taskDir << "/" << GENERATED_PATH;                  // Destination
     if(system(cpCmd.str().c_str()))
     {
@@ -766,7 +766,7 @@ int Composer::generateSupervisor(ComposerGraphI_t* builderGraphI)
     std::stringstream supervisor_hFName;
     supervisor_hFName << outputPath << taskDir << "/" << GENERATED_PATH;
     supervisor_hFName << "/supervisor_generated.h";
-    
+
     std::string supervisor_hFNameStr = supervisor_hFName.str();
 
     supervisor_h.open(supervisor_hFNameStr.c_str());
@@ -782,7 +782,7 @@ int Composer::generateSupervisor(ComposerGraphI_t* builderGraphI)
     std::stringstream supervisor_cppFName;
     supervisor_cppFName << outputPath << taskDir << "/" << GENERATED_PATH;
     supervisor_cppFName << "/supervisor_generated.cpp";
-    
+
     std::string supervisor_cppFNameStr = supervisor_cppFName.str();
 
     supervisor_cpp.open(supervisor_cppFNameStr.c_str());
@@ -796,15 +796,15 @@ int Composer::generateSupervisor(ComposerGraphI_t* builderGraphI)
     writeFileProvenance(supervisor_hFNameStr, builderGraphI, supervisor_h);
     supervisor_h << "#ifndef __SupervisorGeneratedH__H\n";
     supervisor_h << "#define __SupervisorGeneratedH__H\n\n";
-    
+
     writeFileProvenance(supervisor_cppFNameStr, builderGraphI, supervisor_cpp);
     supervisor_cpp << "#include \"supervisor_generated.h\"\n";
     supervisor_cpp << "#include \"Supervisor.h\"\n\n";
 
     // Write the static member initialisors (Supervisor::init and the Device Vector)
     supervisor_cpp << "bool Supervisor::__SupervisorInit = false;\n";
-    
-    
+
+
     // As part of this, we need to generate an edge index for each device on
     // this supervisor. For now, that is all devices so we (ab)use Digraph.
     // TODO: change for multi supervisor.
@@ -845,11 +845,11 @@ int Composer::generateSupervisor(ComposerGraphI_t* builderGraphI)
     }
     supervisor_cpp.seekp(-1,ios_base::cur); // Rewind one place to remove the stray ","
     supervisor_cpp << "\n};\n\n";               // properly terminate the initialiser
-    
-    
+
+
     // Fill a vector of thread hardware addresses that this supervisor is responsible for
     int threadIdx = 0; // Faster than using std::distance
-    
+
     supervisor_cpp << "const std::vector<uint32_t> ";
     supervisor_cpp << "Supervisor::ThreadVector = { ";
     WALKSET(P_core*,(*(builderGraphI->cores)),coreNode)
@@ -862,17 +862,17 @@ int Composer::generateSupervisor(ComposerGraphI_t* builderGraphI)
             {   // if there are devices placed on the thread
                 supervisor_cpp << pThread->get_hardware_address()->as_uint();
                 supervisor_cpp << ",";
-                
+
                 // Add some line splitting
-                if(threadIdx%100 == 0) supervisor_cpp << "\n\t";     
+                if(threadIdx%100 == 0) supervisor_cpp << "\n\t";
                 threadIdx++;
             }
         }
     }
     supervisor_cpp.seekp(-1,ios_base::cur); // Rewind one place to remove the stray ","
     supervisor_cpp << "\n};\n\n";               // properly terminate the initialiser
-    
-    
+
+
     // Add references for static class members
     supervisor_cpp << "SupervisorProperties_t* ";
     supervisor_cpp << "Supervisor::__SupervisorProperties;\n";
@@ -1130,9 +1130,9 @@ void Composer::writeGlobalPropsD(GraphI_t* graphI, std::ofstream& props_h)
 
     props_h << "#ifndef _GLOBALPROPS_H_\n";
     props_h << "#define _GLOBALPROPS_H_\n\n";
-    
+
     std::string fName = "GlobalProperties.h";
-    
+
     props_h << "#include <cstdint>\n";
 
     if(graphT->pPropsD)
@@ -1177,7 +1177,7 @@ void Composer::writeMessageTypes(GraphI_t* graphI, std::ofstream& pkt_h)
 
     pkt_h << "#ifndef _MESSAGETYPES_H_\n";
     pkt_h << "#define _MESSAGETYPES_H_\n\n";
-    
+
     pkt_h << "#include <cstdint>\n";
     //pkt_h << "#include \"softswitch_common.h\"\n\n";
 
@@ -1350,7 +1350,7 @@ void Composer::formDevTHandlers(devTypStrings_t* dTypStrs)
     {
         handlers_cpp << devT->pOnInit->C_src() << "\n";
     }
-    
+
     handlers_cpp << "    return 1;\n"; // A default Return of 1 to trigger RTS
     handlers_cpp << "}\n\n";
 
@@ -1662,16 +1662,16 @@ int Composer::createCoreFiles(P_core* pCore, ComposerGraphI_t* builderGraphI,
 {
     uint32_t coreAddr = pCore->get_hardware_address()->as_uint();
     FILE * fd = pCore->parent->parent->parent->parent->parent->fd;  // Microlog
-    
+
     std::string taskDir = builderGraphI->outputDir;
-    
+
     // Create the vars header
     std::stringstream vars_hFName;
     vars_hFName << outputPath << taskDir << "/" << GENERATED_H_PATH;
     vars_hFName << "/vars_" << coreAddr << ".h";
-    
+
     std::string vars_hFNameStr = vars_hFName.str();
-    
+
     vars_h.open(vars_hFNameStr.c_str());
 
     if(vars_h.fail()) // Check that the file opened
@@ -1687,7 +1687,7 @@ int Composer::createCoreFiles(P_core* pCore, ComposerGraphI_t* builderGraphI,
     std::stringstream vars_cppFName;
     vars_cppFName << outputPath << taskDir << "/" << GENERATED_CPP_PATH;
     vars_cppFName << "/vars_" << coreAddr << ".cpp";
-    
+
     std::string vars_cppFNameStr = vars_cppFName.str();
 
     vars_cpp.open(vars_cppFNameStr.c_str());
@@ -1705,7 +1705,7 @@ int Composer::createCoreFiles(P_core* pCore, ComposerGraphI_t* builderGraphI,
     std::stringstream handlers_hFName;
     handlers_hFName << outputPath << taskDir << "/" << GENERATED_H_PATH;
     handlers_hFName << "/handlers_" << coreAddr << ".h";
-    
+
     std::string handlers_hFNameStr = handlers_hFName.str();
 
     handlers_h.open(handlers_hFNameStr.c_str());
@@ -1725,7 +1725,7 @@ int Composer::createCoreFiles(P_core* pCore, ComposerGraphI_t* builderGraphI,
     std::stringstream handlers_cppFName;
     handlers_cppFName << outputPath << taskDir << "/" << GENERATED_CPP_PATH;
     handlers_cppFName << "/handlers_" << coreAddr << ".cpp";
-    
+
     std::string handlers_cppFNameStr = handlers_cppFName.str();
 
     handlers_cpp.open(handlers_cppFNameStr.c_str());
@@ -1740,11 +1740,11 @@ int Composer::createCoreFiles(P_core* pCore, ComposerGraphI_t* builderGraphI,
         fprintf(fd,"\t\tFailed to open %s\n",handlers_cppFName.str().c_str());
         return -1;
     }
-    
-    
+
+
     writeFileProvenance(vars_hFNameStr, builderGraphI, vars_h);
     writeFileProvenance(vars_cppFNameStr, builderGraphI, vars_cpp);
-    
+
     writeFileProvenance(handlers_hFNameStr, builderGraphI, handlers_h);
     writeFileProvenance(handlers_cppFNameStr, builderGraphI, handlers_cpp);
 
@@ -1836,21 +1836,21 @@ void Composer::writeCoreHandlerFoot(AddressComponent coreAddr,
  *
  * If creation of any of the files fails, all opened ones are closed.
  *****************************************************************************/
-int Composer::createThreadFile(P_thread* pThread, 
+int Composer::createThreadFile(P_thread* pThread,
                                 ComposerGraphI_t* builderGraphI,
                                 std::ofstream& tvars_cpp)
 {
     uint32_t coreAddr = pThread->parent->get_hardware_address()->as_uint();
     uint32_t threadAddr = pThread->get_hardware_address()->get_thread();
-    
+
     std::string taskDir = builderGraphI->outputDir;
-    
+
     // Create the vars source
     std::stringstream tvars_cppFName;
     tvars_cppFName << outputPath << taskDir << "/" << GENERATED_CPP_PATH;
     tvars_cppFName << "/vars_" << coreAddr;
     tvars_cppFName << "_" << threadAddr << ".cpp";
-    
+
     std::string tvars_cppFNameStr = tvars_cppFName.str();
 
     tvars_cpp.open(tvars_cppFNameStr.c_str());
@@ -1861,7 +1861,7 @@ int Composer::createThreadFile(P_thread* pThread,
         //par->Post(816, tvars_cppFName.str(), OSFixes::getSysErrorString(errno));
         return -1;
     }
-    
+
     writeFileProvenance(tvars_cppFNameStr, builderGraphI, tvars_cpp);
 
     return 0;
@@ -2422,7 +2422,7 @@ void Composer::writeThreadDevIDefs(ComposerGraphI_t* builderGraphI,
         {
             devII << "&Thread_" << threadAddr << "_DeviceState[";
             devII << devIdx << "]},";
-            
+
             devSIStrs[devIdx] = "{";
             if(devI->pStateI)
             {
@@ -2658,7 +2658,7 @@ void Composer::writeDevIInputPinEdgeDefs(GraphI_t* graphI, PinI_t* pinI,
             {
                 inEdgeInit << "&" << thrDevName << "_Pin_" << pinI->pT->Name();
                 inEdgeInit << "_InEdgeProps[" << edgeI->Idx << "],";
-                
+
                 inEdgePropsIStrs[edgeI->Idx] = "{";
                 if(edgeI->pPropsI)
                 {
@@ -2675,7 +2675,7 @@ void Composer::writeDevIInputPinEdgeDefs(GraphI_t* graphI, PinI_t* pinI,
             {
                 inEdgeInit << "&" << thrDevName << "_Pin_" << pinI->pT->Name();
                 inEdgeInit << "_InEdgeStates[" << edgeI->Idx << "]},";
-                
+
                 inEdgeStatesIStrs[edgeI->Idx] = "{";
                 if(edgeI->pStateI)
                 {

--- a/Source/OrchBase/Composer.cpp
+++ b/Source/OrchBase/Composer.cpp
@@ -31,7 +31,7 @@ ComposerGraphI_t::ComposerGraphI_t()
 ComposerGraphI_t::ComposerGraphI_t(GraphI_t* graphIIn)
 {
     graphI = graphIIn;
-    outputDir = graphI->Name();
+    outputDir = graphI->GetCompoundName(true);
     generated = false;
     compiled = false;
 }

--- a/Source/OrchBase/Composer.cpp
+++ b/Source/OrchBase/Composer.cpp
@@ -801,9 +801,10 @@ int Composer::generateSupervisor(ComposerGraphI_t* builderGraphI)
     supervisor_cpp << "#include \"supervisor_generated.h\"\n";
     supervisor_cpp << "#include \"Supervisor.h\"\n\n";
 
-    // Write the static member initialisors (Supervisor::init and the Device Vector)
+    // Write the static member initialisors (Supervisor::init, Supervisor::api,
+    // and the Device Vector)
     supervisor_cpp << "bool Supervisor::__SupervisorInit = false;\n";
-
+    supervisor_cpp << "SupervisorApi Supervisor::__api;\n";
 
     // As part of this, we need to generate an edge index for each device on
     // this supervisor. For now, that is all devices so we (ab)use Digraph.

--- a/Source/OrchBase/Composer.cpp
+++ b/Source/OrchBase/Composer.cpp
@@ -1531,9 +1531,11 @@ void Composer::formDevTInputPinHandlers(devTypStrings_t* dTypStrs)
         if ((*pinI)->pMsg->pPropsD)
         {
             handlers_cpp << "   const pkt_" << (*pinI)->pMsg->Name();
-            handlers_cpp << "_pyld_t* message = ";
+            handlers_cpp << "_pyld_t* message";
+            handlers_cpp << " OS_ATTRIBUTE_UNUSED= ";
             handlers_cpp << "static_cast<const pkt_" << (*pinI)->pMsg->Name();
             handlers_cpp << "_pyld_t*>(pkt);\n";
+            handlers_cpp << "OS_PRAGMA_UNUSED(message)\n";
         }
 
         handlers_cpp << (*pinI)->pHandl->C_src() << "\n";
@@ -1591,8 +1593,11 @@ void Composer::formDevTOutputPinHandlers(devTypStrings_t* dTypStrs)
         if (devT->pPinTSO->pMsg->pPropsD)
         {
             handlers_cpp << "   pkt_" << devT->pPinTSO->pMsg->Name();
-            handlers_cpp << "_pyld_t* message = static_cast<pkt_";
+            handlers_cpp << "_pyld_t* message";
+            handlers_cpp << " OS_ATTRIBUTE_UNUSED= ";
+            handlers_cpp << "static_cast<pkt_";
             handlers_cpp << devT->pPinTSO->pMsg->Name() << "_pyld_t*>(pkt);\n";
+            handlers_cpp << "OS_PRAGMA_UNUSED(message)\n";
         }
         handlers_cpp << devT->pPinTSO->pHandl->C_src() << "\n";
 
@@ -1629,8 +1634,11 @@ void Composer::formDevTOutputPinHandlers(devTypStrings_t* dTypStrs)
         if ((*pinO)->pMsg->pPropsD)
         {
             handlers_cpp << "   pkt_" << (*pinO)->pMsg->Name();
-            handlers_cpp << "_pyld_t* message = static_cast<pkt_";
+            handlers_cpp << "_pyld_t* message = ";
+            handlers_cpp << " OS_ATTRIBUTE_UNUSED= ";
+            handlers_cpp << "static_cast<pkt_";
             handlers_cpp << (*pinO)->pMsg->Name() << "_pyld_t*>(pkt);\n";
+            handlers_cpp << "OS_PRAGMA_UNUSED(message)\n";
         }
         handlers_cpp << (*pinO)->pHandl->C_src() << "\n";
 

--- a/Source/OrchBase/Handlers/CmDepl.cpp
+++ b/Source/OrchBase/Handlers/CmDepl.cpp
@@ -44,7 +44,7 @@ void CmDepl::Cm_App(Cli::Cl_t clause)
 #warning "CmBuil::Cm_Deploy: No logic defined for checking whether an application has been built. Deploy-check does not interact with the Composer."
         if (!(*graphIt)->built)
         {
-            par->Post(107, (*graphIt)->Name());
+            par->Post(107, (*graphIt)->GetCompoundName());
             return;
         }
     }
@@ -108,7 +108,8 @@ int CmDepl::DeployGraph(GraphI_t* gi)
     std::vector<PMsg_p*>::iterator messageIt;
 
     /* Other payloady bits. */
-    std::string graphName = gi->Name();
+    std::string graphName = gi->GetCompoundName();
+    std::string graphPathName = gi->GetCompoundName(true);
     unsigned distCount;
     uint8_t appNumber;
     std::string soPath;
@@ -192,10 +193,11 @@ int CmDepl::DeployGraph(GraphI_t* gi)
 
             /* paths */
             payload->codePath = std::string(getenv("HOME")) + "/" +
-                par->pCmPath->pathMshp + graphName + "/" +
+                par->pCmPath->pathMshp + graphPathName + "/" +
                 core->instructionBinary;
             payload->dataPath = std::string(getenv("HOME")) + "/" +
-                par->pCmPath->pathMshp + graphName + "/" + core->dataBinary;
+                par->pCmPath->pathMshp + graphPathName + "/" +
+                core->dataBinary;
 
             /* coreAddr */
             payload->coreAddr = core->get_hardware_address()->as_uint();
@@ -225,10 +227,11 @@ int CmDepl::DeployGraph(GraphI_t* gi)
          * them. To do this, we naively copy all binaries to all Motherships
          * for now. */
         target = dformat("%s/%s/%s", getenv("HOME"),
-                         par->pCmPath->pathMshp.c_str(), graphName.c_str());
+                         par->pCmPath->pathMshp.c_str(),
+                         graphPathName.c_str());
         sourceBinaries = dformat("%s%s/bin/*",
                                  par->pCmPath->pathBina.c_str(),
-                                 graphName.c_str());
+                                 graphPathName.c_str());
 
         /* Identify whether or not this Mothership is running on the same
          * machine as Root, to determine how we deploy binaries. Store the
@@ -316,7 +319,7 @@ int CmDepl::DeployGraph(GraphI_t* gi)
 
         /* Customise and send the SUPD message. */
         soPath = getenv("HOME") + std::string("/") +  par->pCmPath->pathMshp +
-            graphName + "/" + gi->pSupI->binPath;
+            graphPathName + "/" + gi->pSupI->binPath;
         supdMessage.Put(1, &soPath);
         supdMessage.Send();
 

--- a/Source/OrchBase/Handlers/CmPath.cpp
+++ b/Source/OrchBase/Handlers/CmPath.cpp
@@ -245,16 +245,18 @@ fflush(fp);
  * Mothership. */
 void CmPath::UpdateMotherships()
 {
-    PMsg_p out;
-    out.Src(par->Urank);
-    out.Key(Q::PATH);
-    out.Put(0,&pathMout);
-
     /* Send to all Motherships, if any. */
     std::vector<ProcMap::ProcMap_t>::iterator procIt;
     for (procIt=par->pPmap->vPmap.begin();
          procIt!=par->pPmap->vPmap.end(); procIt++)
-        if (procIt->P_class != csMOTHERSHIPproc) out.Send(procIt->P_rank);
+        if (procIt->P_class == csMOTHERSHIPproc)
+        {
+            PMsg_p out;
+            out.Src(par->Urank);
+            out.Key(Q::PATH);
+            out.Put(0,&pathMout);
+            out.Send(procIt->P_rank);
+        }
 }
 
 //------------------------------------------------------------------------------

--- a/Source/OrchBase/Handlers/CmPath.h
+++ b/Source/OrchBase/Handlers/CmPath.h
@@ -26,6 +26,7 @@ FILE *        GetLolfp();
 FILE *        GetOfgfp();
 void          Reset();
 void          Show(FILE * = stdout);
+void          UpdateMotherships();
 unsigned      operator()(Cli *);
 
 OrchBase *    par;
@@ -34,6 +35,7 @@ string        pathBatc;
 string        pathBina;
 string        pathEngi;
 string        pathLog;
+string        pathMout;
 string        pathMshp;
 string        pathPlac;
 string        pathStag;

--- a/Source/OrchBase/OrchBase.h
+++ b/Source/OrchBase/OrchBase.h
@@ -39,7 +39,6 @@ class P_super;
 #include "CmUnpl.h"
 #include "CmUntl.h"
 
-#define TASK_DEPLOY_DIR ".orchestrator/task_binaries"  // Relative to home.
 using namespace std;
 
 //==============================================================================

--- a/Source/OrchBase/OrchBaseMothership.cpp
+++ b/Source/OrchBase/OrchBaseMothership.cpp
@@ -69,7 +69,7 @@ void OrchBase::MshipCommand(Cli::Cl_t clause, std::string command)
     {
         if (!(*graphIt)->deployed)
         {
-            Post(169, command, (*graphIt)->Name());
+            Post(169, command, (*graphIt)->GetCompoundName());
             return;
         }
     }
@@ -78,7 +78,7 @@ void OrchBase::MshipCommand(Cli::Cl_t clause, std::string command)
     for (graphIt = graphs.begin(); graphIt != graphs.end(); graphIt++)
     {
         PMsg_p message;
-        std::string graphName = (*graphIt)->Name();
+        std::string graphName = (*graphIt)->GetCompoundName();
 
         /* Boxes that are relevant for the application being commanded. */
         std::set<P_box*> boxesOfImport;

--- a/Source/Root/OrchConfig.cpp
+++ b/Source/Root/OrchConfig.cpp
@@ -62,17 +62,18 @@ WALKVECTOR(UIF::Node *,sects,i) {      // Walk the sections
       if (valus.size()>1) IncErr(P.FndRecd(*k),3);
       if (valus.empty()) s.clear();
       else s = valus[0]->str;
-      if ((*k)->str=="apps"        ) default_paths.apps        = s;
-      if ((*k)->str=="engine"      ) default_paths.engine      = s;
-      if ((*k)->str=="place"       ) default_paths.place       = s;
-      if ((*k)->str=="log"         ) default_paths.log         = s;
-      if ((*k)->str=="ulog"        ) default_paths.ulog        = s;
-      if ((*k)->str=="trace"       ) default_paths.trace       = s;
-      if ((*k)->str=="binaries"    ) default_paths.binaries    = s;
-      if ((*k)->str=="stage"       ) default_paths.stage       = s;
-      if ((*k)->str=="batch"       ) default_paths.batch       = s;
-      if ((*k)->str=="supervisors" ) default_paths.supervisors = s;
-      if ((*k)->str=="remote_mship") default_paths.remote_mship = s;
+      if ((*k)->str=="apps"         ) default_paths.apps          = s;
+      if ((*k)->str=="engine"       ) default_paths.engine        = s;
+      if ((*k)->str=="place"        ) default_paths.place         = s;
+      if ((*k)->str=="log"          ) default_paths.log           = s;
+      if ((*k)->str=="ulog"         ) default_paths.ulog          = s;
+      if ((*k)->str=="trace"        ) default_paths.trace         = s;
+      if ((*k)->str=="binaries"     ) default_paths.binaries      = s;
+      if ((*k)->str=="stage"        ) default_paths.stage         = s;
+      if ((*k)->str=="batch"        ) default_paths.batch         = s;
+      if ((*k)->str=="supervisors"  ) default_paths.supervisors   = s;
+      if ((*k)->str=="remote_mship" ) default_paths.remote_mship  = s;
+      if ((*k)->str=="remote_outdir") default_paths.remote_outdir = s;
     }
   }
   if (sn=="setup_files") {

--- a/Source/Root/OrchConfig.h
+++ b/Source/Root/OrchConfig.h
@@ -39,6 +39,7 @@ string                   Name()        { return Orchestrator_header.name;      }
 string                   Place()       { return default_paths.place;           }
 string                   Placement()   { return setup_files.placement;         }
 string                   RemoteMshp()  { return default_paths.remote_mship;    }
+string                   RemoteOut()   { return default_paths.remote_outdir;   }
 string                   Trace()       { return default_paths.trace;           }
 string                   Stage()       { return default_paths.stage;           }
 string                   Supervisors() { return default_paths.supervisors;     }
@@ -71,6 +72,7 @@ struct default_paths_t {               // Default file paths
   string batch;
   string supervisors;
   string remote_mship;
+  string remote_outdir;
 } default_paths;
 
 struct setup_files_t {

--- a/Source/Root/Root.h
+++ b/Source/Root/Root.h
@@ -47,6 +47,7 @@ unsigned                    OnInje(PMsg_p *);
 unsigned                    OnKeyb(PMsg_p *);
 unsigned                    OnLogP(PMsg_p *);
 unsigned                    OnMshipAck(PMsg_p *);
+unsigned                    OnMshipReq(PMsg_p *);
 unsigned                    OnPmap(PMsg_p *);
 unsigned                    OnTest(PMsg_p *);
 unsigned                    ProcCmnd(Cli *);

--- a/Source/Softswitch/Makefile
+++ b/Source/Softswitch/Makefile
@@ -98,6 +98,7 @@ vpath MessageFormats.h $(GENDIR)
 vpath GlobalProperties.h $(GENDIR)
 vpath OSFixes.hpp $(GENERICSINC)
 vpath Supervisor.% $(realpath ../$(DEFAULT_GEN_DIR))
+vpath SupervisorApi.% $(realpath ../$(DEFAULT_GEN_DIR))
 VPATH := $(SOFTSWSRC):$(SOFTSWINC):$(TINSELLIB):$(TINSELINC):$(GENERICSINC):$(GENDIR)
 
 # Local compiler flags
@@ -125,7 +126,7 @@ all : $(TARGETS) $(VCTARGETS) $(VDTARGETS) supervisor
 
 supervisor: $(BINDIR)/libSupervisor.so
 
-$(BINDIR)/libSupervisor.so: Supervisor.cpp Supervisor.h supervisor_generated.cpp supervisor_generated.h
+$(BINDIR)/libSupervisor.so: Supervisor.cpp Supervisor.h supervisor_generated.cpp supervisor_generated.h SupervisorApi.h
 	$(MPICXX) $(MPICFLAGS) $(MPILDFLAGS) -O3 -Wl,-soname,libSupervisor.so -o $@ $<
 
 $(BINDIR)/softswitch_code_%.v: $(BINDIR)/softswitch_%.elf

--- a/Source/Softswitch/Makefile
+++ b/Source/Softswitch/Makefile
@@ -99,6 +99,7 @@ vpath GlobalProperties.h $(GENDIR)
 vpath OSFixes.hpp $(GENERICSINC)
 vpath Supervisor.% $(realpath ../$(DEFAULT_GEN_DIR))
 vpath SupervisorApi.% $(realpath ../$(DEFAULT_GEN_DIR))
+vpath SupervisorApiEntrypoints.% $(realpath ../$(DEFAULT_GEN_DIR))
 VPATH := $(SOFTSWSRC):$(SOFTSWINC):$(TINSELLIB):$(TINSELINC):$(GENERICSINC):$(GENDIR)
 
 # Local compiler flags
@@ -126,7 +127,7 @@ all : $(TARGETS) $(VCTARGETS) $(VDTARGETS) supervisor
 
 supervisor: $(BINDIR)/libSupervisor.so
 
-$(BINDIR)/libSupervisor.so: Supervisor.cpp Supervisor.h supervisor_generated.cpp supervisor_generated.h SupervisorApi.h
+$(BINDIR)/libSupervisor.so: Supervisor.cpp Supervisor.h supervisor_generated.cpp supervisor_generated.h SupervisorApi.h SupervisorApiEntrypoints.h
 	$(MPICXX) $(MPICFLAGS) $(MPILDFLAGS) -O3 -Wl,-soname,libSupervisor.so -o $@ $<
 
 $(BINDIR)/softswitch_code_%.v: $(BINDIR)/softswitch_%.elf

--- a/Source/Supervisor/Supervisor.cpp
+++ b/Source/Supervisor/Supervisor.cpp
@@ -3,8 +3,10 @@
 
 extern "C"
 {
+    SupervisorApi* GetSupervisorApi(){return &(Supervisor::api);}
+
     int SupervisorInit(){return Supervisor::OnInit();}
-    
+
     int SupervisorCall(PMsg_p* In, PMsg_p* Out)
     {
 #ifdef _APPLICATION_SUPERVISOR_
@@ -36,17 +38,17 @@ extern "C"
     uint64_t SupervisorIdx2Addr(uint32_t idx)
     {
         uint64_t ret = 0;
-        
+
         if(idx >= Supervisor::DeviceVector.size())
         {
-            //out of range Idx            
+            //out of range Idx
             return UINT64_MAX;
         }
-        
+
         ret = Supervisor::DeviceVector[idx].HwAddr;
         ret = ret << 32;
         ret |= Supervisor::DeviceVector[idx].SwAddr;
-        
+
         return ret;
     }
 

--- a/Source/Supervisor/Supervisor.cpp
+++ b/Source/Supervisor/Supervisor.cpp
@@ -3,7 +3,7 @@
 
 extern "C"
 {
-    SupervisorApi* GetSupervisorApi(){return &(Supervisor::api);}
+    SupervisorApi* GetSupervisorApi(){return &(Supervisor::__api);}
 
     int SupervisorInit(){return Supervisor::OnInit();}
 

--- a/Source/Supervisor/Supervisor.h
+++ b/Source/Supervisor/Supervisor.h
@@ -26,7 +26,7 @@ class Supervisor
 {
 public:
    static bool __SupervisorInit;
-   static SupervisorApi api;
+   static SupervisorApi __api;
 
    static SupervisorProperties_t* __SupervisorProperties;
    static SupervisorState_t* __SupervisorState;

--- a/Source/Supervisor/Supervisor.h
+++ b/Source/Supervisor/Supervisor.h
@@ -45,5 +45,6 @@ public:
 
 };
 
+#include "SupervisorApiEntrypoints.h"
 
 #endif

--- a/Source/Supervisor/Supervisor.h
+++ b/Source/Supervisor/Supervisor.h
@@ -5,9 +5,10 @@
 #include "poets_pkt.h"
 #include "OSFixes.hpp"
 #include "supervisor_generated.h"
+#include "SupervisorApi.h"
 
 #include <cstdint>
-#include <string>                 
+#include <string>
 #include <iostream>
 #include <vector>
 #include <map>
@@ -19,28 +20,29 @@ typedef struct SupervisorDeviceInstance_t
     std::string Name;   // Temporary until we have Nameserver
 } SupervisorDeviceInstance_t;
 
+class SupervisorApi;
+
 class Supervisor
 {
 public:
    static bool __SupervisorInit;
-   
+   static SupervisorApi api;
+
    static SupervisorProperties_t* __SupervisorProperties;
    static SupervisorState_t* __SupervisorState;
-   
-   
+
    static const std::vector<SupervisorDeviceInstance_t> DeviceVector;
    static const std::vector<uint32_t> ThreadVector;
-   
+
    static int OnImplicit(P_Pkt_t*);
    static int OnPkt(P_Pkt_t*);
-   
+
    static int OnInit();
    static int OnStop();
    static int OnCtl();
    static int OnIdle();
    static int OnRTCL();
-   
-   
+
 };
 
 

--- a/Source/Supervisor/SupervisorApi.h
+++ b/Source/Supervisor/SupervisorApi.h
@@ -13,6 +13,7 @@ class SupervisorApi
 public:
     Mothership* mship;
     std::string appName;
+    void (*post)(Mothership* mship, std::string message);
     void (*stop_application)(Mothership* mship, std::string appName);
 };
 

--- a/Source/Supervisor/SupervisorApi.h
+++ b/Source/Supervisor/SupervisorApi.h
@@ -1,16 +1,10 @@
 #ifndef __SupervisorApiH__H
 #define __SupervisorApiH__H
 
-#include <string>
-
 /* This class holds a series of function pointers that perform
- * "privilege-escalated" jobs using Mothership logic. It also defines a set of
- * macros so that the application-writer can call the functions pointed to by
- * the function pointers. */
+ * "privilege-escalated" jobs using Mothership logic. */
 
-#define SUPERVISOR_STOP_APPLICATION() \
-    ((Supervisor::__api.stop_application)\
-     (Supervisor::__api.mship, Supervisor::__api.appName))
+#include <string>
 
 class Mothership;
 

--- a/Source/Supervisor/SupervisorApi.h
+++ b/Source/Supervisor/SupervisorApi.h
@@ -13,7 +13,7 @@ class SupervisorApi
 public:
     Mothership* mship;
     std::string appName;
-    void (*post)(Mothership* mship, std::string message);
+    void (*post)(Mothership* mship, std::string appName, std::string message);
     void (*stop_application)(Mothership* mship, std::string appName);
 };
 

--- a/Source/Supervisor/SupervisorApi.h
+++ b/Source/Supervisor/SupervisorApi.h
@@ -9,8 +9,8 @@
  * the function pointers. */
 
 #define SUPERVISOR_STOP_APPLICATION() \
-    ((Supervisor::api.stop_application)\
-     (Supervisor::api.mship, Supervisor::api.appName))
+    ((Supervisor::__api.stop_application)\
+     (Supervisor::__api.mship, Supervisor::__api.appName))
 
 class Mothership;
 

--- a/Source/Supervisor/SupervisorApi.h
+++ b/Source/Supervisor/SupervisorApi.h
@@ -9,15 +9,17 @@
  * the function pointers. */
 
 #define SUPERVISOR_STOP_APPLICATION() \
-    ((Supervisor::api.*stop_application)(Supervisor::api.appName))
+    ((Supervisor::api.stop_application)\
+     (Supervisor::api.mship, Supervisor::api.appName))
 
 class Mothership;
 
 class SupervisorApi
 {
 public:
+    Mothership* mship;
     std::string appName;
-    void (Mothership::*stop_application)(std::string appName);
+    void (*stop_application)(Mothership* mship, std::string appName);
 };
 
 #endif

--- a/Source/Supervisor/SupervisorApi.h
+++ b/Source/Supervisor/SupervisorApi.h
@@ -1,0 +1,23 @@
+#ifndef __SupervisorApiH__H
+#define __SupervisorApiH__H
+
+#include <string>
+
+/* This class holds a series of function pointers that perform
+ * "privilege-escalated" jobs using Mothership logic. It also defines a set of
+ * macros so that the application-writer can call the functions pointed to by
+ * the function pointers. */
+
+#define SUPERVISOR_STOP_APPLICATION() \
+    ((Supervisor::api.*stop_application)(Supervisor::api.appName))
+
+class Mothership;
+
+class SupervisorApi
+{
+public:
+    std::string appName;
+    void (Mothership::*stop_application)(std::string appName);
+};
+
+#endif

--- a/Source/Supervisor/SupervisorApi.h
+++ b/Source/Supervisor/SupervisorApi.h
@@ -13,6 +13,8 @@ class SupervisorApi
 public:
     Mothership* mship;
     std::string appName;
+    std::string (*get_output_directory)(Mothership* mship, std::string appName,
+                                        std::string suffix);
     void (*post)(Mothership* mship, std::string appName, std::string message);
     void (*stop_application)(Mothership* mship, std::string appName);
 };

--- a/Source/Supervisor/SupervisorApi.h
+++ b/Source/Supervisor/SupervisorApi.h
@@ -5,6 +5,7 @@
  * "privilege-escalated" jobs using Mothership logic. */
 
 #include <string>
+#include "poets_pkt.h"
 
 class Mothership;
 
@@ -16,6 +17,8 @@ public:
     std::string (*get_output_directory)(Mothership* mship, std::string appName,
                                         std::string suffix);
     void (*post)(Mothership* mship, std::string appName, std::string message);
+    void (*push_packets)(Mothership* mship,
+                         std::vector<std::pair<uint32_t, P_Pkt_t> >& packets);
     void (*stop_application)(Mothership* mship, std::string appName);
 };
 

--- a/Source/Supervisor/SupervisorApiEntrypoints.h
+++ b/Source/Supervisor/SupervisorApiEntrypoints.h
@@ -5,7 +5,7 @@
  * application can call, which piggyback off functions defined in the
  * SupervisorApi class. */
 
-namespace SuperApi {
+namespace Super {
     void stop_application()
     {
         (Supervisor::__api.stop_application)

--- a/Source/Supervisor/SupervisorApiEntrypoints.h
+++ b/Source/Supervisor/SupervisorApiEntrypoints.h
@@ -6,6 +6,13 @@
  * SupervisorApi class. */
 
 namespace Super {
+    void get_output_directory(std::string suffix="")
+    {
+        (Supervisor::__api.get_output_directory)(Supervisor::__api.mship,
+                                                 Supervisor::__api.appName,
+                                                 suffix);
+    }
+
     void post(std::string message)
     {
         (Supervisor::__api.post)(Supervisor::__api.mship,
@@ -15,8 +22,8 @@ namespace Super {
 
     void stop_application()
     {
-        (Supervisor::__api.stop_application)
-            (Supervisor::__api.mship, Supervisor::__api.appName);
+        (Supervisor::__api.stop_application)(Supervisor::__api.mship,
+                                             Supervisor::__api.appName);
     }
 }
 

--- a/Source/Supervisor/SupervisorApiEntrypoints.h
+++ b/Source/Supervisor/SupervisorApiEntrypoints.h
@@ -1,0 +1,16 @@
+#ifndef __SupervisorApiEntrypointsH__H
+#define __SupervisorApiEntrypointsH__H
+
+/* This header contains namespaced functions that a supervisor device in an
+ * application can call, which piggyback off functions defined in the
+ * SupervisorApi class. */
+
+namespace SuperApi {
+    void stop_application()
+    {
+        (Supervisor::__api.stop_application)
+            (Supervisor::__api.mship, Supervisor::__api.appName);
+    }
+}
+
+#endif

--- a/Source/Supervisor/SupervisorApiEntrypoints.h
+++ b/Source/Supervisor/SupervisorApiEntrypoints.h
@@ -6,11 +6,12 @@
  * SupervisorApi class. */
 
 namespace Super {
-    void get_output_directory(std::string suffix="")
+    std::string get_output_directory(std::string suffix="")
     {
-        (Supervisor::__api.get_output_directory)(Supervisor::__api.mship,
-                                                 Supervisor::__api.appName,
-                                                 suffix);
+        return (Supervisor::__api.get_output_directory)
+            (Supervisor::__api.mship,
+             Supervisor::__api.appName,
+             suffix);
     }
 
     void post(std::string message)

--- a/Source/Supervisor/SupervisorApiEntrypoints.h
+++ b/Source/Supervisor/SupervisorApiEntrypoints.h
@@ -6,6 +6,11 @@
  * SupervisorApi class. */
 
 namespace Super {
+    void post(std::string message)
+    {
+        (Supervisor::__api.post)(Supervisor::__api.mship, message);
+    }
+
     void stop_application()
     {
         (Supervisor::__api.stop_application)

--- a/Source/Supervisor/SupervisorApiEntrypoints.h
+++ b/Source/Supervisor/SupervisorApiEntrypoints.h
@@ -8,7 +8,9 @@
 namespace Super {
     void post(std::string message)
     {
-        (Supervisor::__api.post)(Supervisor::__api.mship, message);
+        (Supervisor::__api.post)(Supervisor::__api.mship,
+                                 Supervisor::__api.appName,
+                                 message);
     }
 
     void stop_application()


### PR DESCRIPTION
For #164.

This changeset introduces the Supervisor API, as per the documentation PR. A brief, user-facing synopsis:

 - Application writers can stop their application from the supervisor by calling `Super::stop_application()` from any execution context or handler.
 - Application writers can post to the Logserver from the supervisor by calling `Super::post(std::string message)` from any execution context or handler.
 - Application writers can get a timestamped directory that is guaranteed-writable at the time of creation, by calling `Super::get_output_directory(std::string suffix)`. A `remote_outdir` Orchestrator configuration option is introduced for specifying a default 'root' output directory.
 - Graeme can call the hidden supervisor API function pointer `(Supervisor::__api.push_packets)(Mothership* Supervisor::__api.mship, std::vector<std::pair<uint32_t, P_Pkt_t> >& packets)` to stage a set of compute-fabric-bound packets.

A developer-facing synopsis:

 - Introduces the `SupervisorAPI` class; an instance of which is held by the `Supervisor` object in the shared object file. The class fundamentally consists of a set of data pointers and function pointers.
 - A set of namespaced functions are defined for use in user-supervisor-code, which call these function pointers when the application is running.
 - The Mothership grabs the `SupervisorAPI` instance from the shared object file at `deploy /app` time and `stop /app` time, and populates the data and function pointers. Function pointers are populated by namespaced Free functions that pass a pointer to the Mothership as an argument.
 - Introduces a mechanism to get a directory-friendly name from a compound application-graphinstance name (i.e. one that doesn't use colons), and uses this mechanism in both the Composer and the Mothership.
 - Introduces a couple of message types:
   -  `Q::MSHP,Q::REQ,Q::STOP` is sent by the Mothership to Root when the user calls `Super::stop_application`. On receipt, Root commands all Motherships hosting the application to stop (using the traditional `Q::CMND,Q::STOP` message).
   - `Q::PATH` is sent by Root to Motherships when the Mothership output path is defined (or changed, or reset), so that the Mothership has access to the `remote_outdir` piece of configuration data.

Sorry about the whitespace removal.

Documentation PR: https://github.com/POETSII/orchestrator-documentation/pull/6

Examples/tests PR: https://github.com/POETSII/Orchestrator_examples/pull/4