### PR TITLE
Support device density constraints that are more relaxed than the default

### DIFF
--- a/Source/OrchBase/Placement/Placer.cpp
+++ b/Source/OrchBase/Placement/Placer.cpp
@@ -475,7 +475,7 @@ float Placer::compute_fitness(P_task* task)
  * globally, or to a given task. */
 unsigned Placer::constrained_max_devices_per_thread(P_task* task)
 {
-    unsigned maximumSoFar = MAX_DEVICES_PER_THREAD_DEFAULT;
+    unsigned maximumSoFar = UINT_MAX;
 
     /* Iterate through each constraint. */
     std::list<Constraint*>::iterator constraintIterator;
@@ -499,7 +499,10 @@ unsigned Placer::constrained_max_devices_per_thread(P_task* task)
             }
         }
     }
-    return maximumSoFar;
+
+    /* If unconstrained, apply a default. */
+    if (maximumSoFar == UINT_MAX) return MAX_DEVICES_PER_THREAD_DEFAULT;
+    else return maximumSoFar;
 }
 
 /* Returns the maximum number of threads that can be used on a core, such that


### PR DESCRIPTION
Resolves issue #176.

The imposed constraint was being ignored in place of the default (256), as the default was more strict than the applied constraint (261). This change means any imposed constraint, no matter how lax, is respected over the default value for the constraint.

Tested by placing the failing-plate example identified in the aforementioned issue for varying device densities, and by plotting histograms of device density for each imposed constraint tested. Tested with values 261 (xpass), 262 (xpass), 256 (xfail), 5 (xfail), 1 (xfail), and with no value imposed (xfail).

Note that development is the merge target - feel free to propagate the changes upstream.