### PR TITLE
Introduces in-place simulated annealing, configurable at compile time.

### DIFF
--- a/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.cpp
+++ b/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.cpp
@@ -82,13 +82,19 @@ float SimulatedAnnealing::do_it(GraphI_t* gi)
 
     /* If the caller requests an in-place anneal, check if the graph is
      * placed. If it's not, issue a warning. */
-    if (inPlace and
-        (placer->placedGraphs.find(gi) != placer->placedGraphs.end()))
+    std::map<GraphI_t*, Algorithm*>::iterator algorithmIt;
+    algorithmIt = placer->placedGraphs.find(gi);
+    if (inPlace and (algorithmIt == placer->placedGraphs.end()))
     {
         fprintf(log, "[W] Initial placement requested, but this graph "
                      "instance has not been placed.\n");
     }
-    else if (inPlace) fprintf(log, "[I] Annealing on existing placement.\n");
+    else if (inPlace)
+    {
+        fprintf(log, "[I] Annealing on an existing placement.\n");
+        /* Clear old algorithm object. */
+        delete algorithmIt->second;
+    }
     else
     {
         /* Initial placement using smart-random. Note that we rely on this

--- a/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.cpp
+++ b/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.cpp
@@ -84,19 +84,11 @@ float SimulatedAnnealing::do_it(GraphI_t* gi)
      * placed. If it's not, issue a warning. */
     std::map<GraphI_t*, Algorithm*>::iterator algorithmIt;
     algorithmIt = placer->placedGraphs.find(gi);
-    if (inPlace and (algorithmIt == placer->placedGraphs.end()))
+    if (algorithmIt == placer->placedGraphs.end())  /* Not placed. */
     {
-        fprintf(log, "[W] Initial placement requested, but this graph "
-                     "instance has not been placed.\n");
-    }
-    else if (inPlace)
-    {
-        fprintf(log, "[I] Annealing on an existing placement.\n");
-        /* Clear old algorithm object. */
-        delete algorithmIt->second;
-    }
-    else
-    {
+        if (inPlace) fprintf(log, "[W] Initial placement requested, but this "
+                                  "graph instance has not been placed.\n");
+
         /* Initial placement using smart-random. Note that we rely on this
          * being a valid placement in order for this algorithm to select across
          * the domain. (MLV never writes broken code! >_>). If it doesn't work,
@@ -110,6 +102,11 @@ float SimulatedAnnealing::do_it(GraphI_t* gi)
             ThreadFilling otherInitialAlgorithm = ThreadFilling(placer);
             otherInitialAlgorithm.do_it(gi);
         }
+    }
+    else if (inPlace)  /* Was already placed, as user intended. */
+    {
+        fprintf(log, "[I] Annealing on an existing placement.\n");
+        delete algorithmIt->second;  /* Clear old algorithm object. */
     }
 
     /* Compute fitness of initial placement. */

--- a/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.h
+++ b/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.h
@@ -21,10 +21,11 @@ class HardwareIterator;
 class SimulatedAnnealing: public Algorithm
 {
 public:
-    SimulatedAnnealing(Placer* placer, bool disorder=true);
+    SimulatedAnnealing(Placer* placer, bool disorder=true, bool inPlace=true);
 
-    unsigned iteration;
     bool disorder;
+    bool inPlace;
+    unsigned iteration;
 
     /* Holds, for each device type, which cores are valid for placement of
      * devices of that type. */

--- a/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.h
+++ b/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.h
@@ -21,7 +21,7 @@ class HardwareIterator;
 class SimulatedAnnealing: public Algorithm
 {
 public:
-    SimulatedAnnealing(Placer* placer, bool disorder=true, bool inPlace=true);
+    SimulatedAnnealing(Placer* placer, bool disorder=true, bool inPlace=false);
 
     bool disorder;
     bool inPlace;

--- a/Source/OrchBase/Placement/Placer.cpp
+++ b/Source/OrchBase/Placement/Placer.cpp
@@ -1139,9 +1139,7 @@ float Placer::place(GraphI_t* gi, Algorithm* algorithm)
      * NB: This supervisor binary is not mapped to boxes (because for now,
      * nobody actually cares). Later on, graph instances will need a map of box
      * keys to supervisor values, for when supervisors differ across boxes. */
-    gi->pSupI = new P_super;
-
-
+    if (gi->pSupI == PNULL) gi->pSupI = new P_super;
     return score;
 }
 
@@ -1413,6 +1411,7 @@ void Placer::unplace(GraphI_t* gi, bool andConstraints)
 
     /* No more supervisor. */
     delete gi->pSupI;
+    gi->pSupI = PNULL;
 }
 
 /* Updates the software addresses of each device in an application graph


### PR DESCRIPTION
Resolves #183. Soon to be "enabled" by the #184 PR.

Tested using [this](https://github.com/POETSII/Orchestrator/files/6454591/0183_diff.txt) patch (to enable it), with the `test_ddos_supervisor` example. By setting the iteration count to 1, the initial placement result will be (almost) preserved. Enabling in-place annealing with this batch script:

```
load /app = +"test_ddos_supervisor.xml"
tlink /app = *
placement /constrain = "DevicesPerThread",2
placement /constrain = "ThreadsPerCore",1
placement /bucket = *
placement /sa = *
placement /dump = *
``` 

will output a bucket placement in the dump, but will error if in-place annealing is disabled. With this script:

```
load /app = +"test_ddos_supervisor.xml"
tlink /app = *
placement /constrain = "DevicesPerThread",2
placement /constrain = "ThreadsPerCore",1
placement /sa = *
placement /dump = *
``` 

with in-place annealing enabled, a warning is posted in the annealer log, and a smart-random starting placement is used as usual.