### PR TITLE
Support arguments for placement algorithms.

### DIFF
--- a/Build/gcc/Makefile.executable_prerequisites
+++ b/Build/gcc/Makefile.executable_prerequisites
@@ -85,6 +85,7 @@ XML_PARSER_SOURCES += $(wildcard $(SOURCE_DIR)/OrchBase/XMLProcessing/*.cpp)
 
 # Sources used by placement
 PLACEMENT_SOURCES = $(SOURCE_DIR)/OrchBase/Placement/CostCache.cpp \
+                    $(SOURCE_DIR)/OrchBase/Placement/PlaceArgs.cpp \
                     $(SOURCE_DIR)/OrchBase/Placement/Placer.cpp \
                     $(SOURCE_DIR)/Common/SoftwareAddress.cpp \
                     $(SOURCE_DIR)/OrchBase/Placement/Algorithms/PlacementLoader.cpp \

--- a/Config/OrchestratorMessages.ocfg
+++ b/Config/OrchestratorMessages.ocfg
@@ -176,6 +176,8 @@
 323(I) : "Constraining the maximum number of threads used for placement on each core in the hardware model to %s."
 324(W) : "Graph instance '%s' has not been type-linked. Not %s."
 325(W) : "Unable to place graph instance '%s' using the '%s' method - %s"
+326(I) : "Placement argument '%s' set to value '%s'."
+327(W) : "Could not set value of placement argument '%s' to '%s' - %s"
 
 500(F) : "Mothership: Could not create pthread %s. Exiting."
 501(F) : "Mothership: Could not join to pthread %s. Exiting."

--- a/Config/OrchestratorMessages.ocfg
+++ b/Config/OrchestratorMessages.ocfg
@@ -175,6 +175,7 @@
 322(I) : "Constraining the maximum number of placed devices per thread in the hardware model to %s."
 323(I) : "Constraining the maximum number of threads used for placement on each core in the hardware model to %s."
 324(W) : "Graph instance '%s' has not been type-linked. Not %s."
+325(W) : "Unable to place graph instance '%s' using the '%s' method - %s"
 
 500(F) : "Mothership: Could not create pthread %s. Exiting."
 501(F) : "Mothership: Could not join to pthread %s. Exiting."

--- a/Source/OrchBase/Handlers/CmPlac.cpp
+++ b/Source/OrchBase/Handlers/CmPlac.cpp
@@ -73,8 +73,8 @@ unsigned CmPlac::operator()(Cli* cli)
 
         /* If we don't know what it is, we whinge. The second predicate is for
          * safety (safety nets cost little, bad UX costs a lot). */
-        if (!isSomething or !isClauseValid) par->Post(25, clause->Cl,
-                                                      "placement");
+        if (!isSomething and !isClauseValid) par->Post(25, clause->Cl,
+                                                       "placement");
     }
     return 0;
 }

--- a/Source/OrchBase/Handlers/CmPlac.cpp
+++ b/Source/OrchBase/Handlers/CmPlac.cpp
@@ -74,7 +74,10 @@ unsigned CmPlac::operator()(Cli* cli)
     return 0;
 }
 
-/* Dumps the command object, not placement information. */
+/* Dumps the command object, not placement information. Since it's stateless,
+ * this is a bit pointless, but continuity matters. If you want to dump
+ * placement information, try 'placement /dump = *', or 'show /placement' for
+ * something more digestible. */
 void CmPlac::Dump(FILE * fp)
 {
 fprintf(fp,"CmPlac+++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n");
@@ -319,16 +322,16 @@ bool CmPlac::PlacementSetArg(Cli::Cl_t clause)
     }
 
     /* Have a go. */
+    std::string proposedValue = clause.Pa_v[0].Concatenate();
     try
     {
-        std::string value = Pa_v[0].Concatenate();
-        par->pPlacer->args.set(clause.Cl, value);
-        par->Post(326, clause.Cl, value);  /* Success */
+        par->pPlacer->args.set(clause.Cl, proposedValue);
+        par->Post(326, clause.Cl, proposedValue);  /* Success */
     }
 
     catch (InvalidArgumentException& e)
     {
-        par->Post(327, clause.Cl, value, e.message);  /* Failure */
+        par->Post(327, clause.Cl, proposedValue, e.message);  /* Failure */
     }
 
     return true;  /* The clause was valid (we checked earlier) */
@@ -349,20 +352,4 @@ void CmPlac::PlacementUnplace(Cli::Cl_t clause)
         par->pPlacer->unplace(*graphIt);
         par->Post(307, (*graphIt)->Name());
     }
-}
-
-/* Synopsis of placement information. */
-void CmPlac::Show(FILE* fp)
-{
-    fprintf(fp,
-            "\nPlacement subsystem attributes and state:\n"
-            "Number of graphs placed: %lu\n"
-            "Number of devices placed: %lu\n"
-            "Number of threads used for placement: %lu\n"
-            "Number of explicit constraints defined: %lu\n",
-            par->pPlacer->placedGraphs.size(),
-            par->pPlacer->deviceToThread.size(),
-            par->pPlacer->threadToDevices.size(),
-            par->pPlacer->constraints.size());
-    fflush(fp);
 }

--- a/Source/OrchBase/Handlers/CmPlac.cpp
+++ b/Source/OrchBase/Handlers/CmPlac.cpp
@@ -197,6 +197,8 @@ bool CmPlac::PlacementDoIt(Cli::Cl_t clause)
                                              e.message);}
     catch (FileOpenException& e) {par->Post(318, (*graphIt)->Name(),
                                             e.message);}
+    catch (InvalidArgumentException& e) {par->Post(325, (*graphIt)->Name(),
+                                                   clause.Cl, e.message);}
     catch (NoEngineException&) {par->Post(305, (*graphIt)->Name());}
     catch (NoSpaceToPlaceException&) {par->Post(306, (*graphIt)->Name());}
     return true;

--- a/Source/OrchBase/Handlers/CmPlac.cpp
+++ b/Source/OrchBase/Handlers/CmPlac.cpp
@@ -33,6 +33,14 @@ unsigned CmPlac::operator()(Cli* cli)
          * clause). */
         bool isClauseValid = true;
         clauseRoot = clause->Cl.substr(0, 4);
+
+        /* The following might not make sense, but before we enter our
+         * conditional hell, we want to be able to disambiguate between clauses
+         * that invoke algorithms, and clauses that set arguments. */
+        bool isAlgorithm;
+        bool isSomething = par->pPlacer->algorithm_or_argument(clauseRoot,
+                                                               isAlgorithm);
+
         if (clauseRoot == "dump") PlacementDump(*clause);
         else if (clauseRoot == "unpl") PlacementUnplace(*clause);
 
@@ -54,10 +62,7 @@ unsigned CmPlac::operator()(Cli* cli)
 
         /* If nothing is appropriate, the operator is either setting an
          * argument or wanting to run a placement algorithm (or they're an
-         * idiot). Ask the placer which it is. */
-        bool isAlgorithm;
-        bool isSomething = par->pPlacer->algorithm_or_argument(clauseRoot,
-                                                               isAlgorithm);
+         * idiot). */
         if (isSomething)
         {
             if (isAlgorithm)

--- a/Source/OrchBase/Handlers/CmPlac.h
+++ b/Source/OrchBase/Handlers/CmPlac.h
@@ -20,10 +20,10 @@ void          PlacementConstrain(Cli::Cl_t clause);
 bool          PlacementDoIt(Cli::Cl_t clause);
 void          PlacementDump(Cli::Cl_t clause);
 void          PlacementLoad(Cli::Cl_t clause);
+bool          PlacementSetArg(Cli::Cl_t clause);
 void          PlacementUnplace(Cli::Cl_t clause);
 
 void          Dump(FILE * = stdout);
-void          Show(FILE * = stdout);
 unsigned      operator()(Cli *);
 
 OrchBase *    par;

--- a/Source/OrchBase/Handlers/CmShow.cpp
+++ b/Source/OrchBase/Handlers/CmShow.cpp
@@ -37,6 +37,41 @@ void CmShow::Cm_Engine(FILE* fp)
 
 //------------------------------------------------------------------------------
 
+void CmShow::Cm_Plac(FILE* fp)
+{
+    if (par->pPlacer == PNULL)
+    {
+        fprintf(fp, "No engine (hardware model) loaded.\n");
+    }
+    else
+    {
+        fprintf(fp,
+                "\nPlacement subsystem attributes and state:\n"
+                "Number of graphs placed: %lu\n"
+                "Number of devices placed: %lu\n"
+                "Number of threads used for placement: %lu\n"
+                "Number of explicit constraints defined: %lu\n",
+                par->pPlacer->placedGraphs.size(),
+                par->pPlacer->deviceToThread.size(),
+                par->pPlacer->threadToDevices.size(),
+                par->pPlacer->constraints.size());
+        if (par->pPlacer->args.size() == 0) fprintf(fp, "No staged arguments.\n");
+        else
+        {
+            fprintf(fp, "Staged arguments:\n");
+            std::map<std::string, std::string> args;
+            par->pPlacer->args.copy_to(args);
+            std::map<std::string, std::string>::iterator argIt;
+            for (argIt = args.begin(); argIt != args.end(); argIt++)
+                fprintf(fp, " - %s: %s\n",
+                        argIt->first.c_str(), argIt->second.c_str());
+        }
+        fflush(fp);
+    }
+}
+
+//------------------------------------------------------------------------------
+
 void CmShow::Dump(FILE * fp)
 {
 fprintf(fp,"CmShow+++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n");
@@ -66,7 +101,7 @@ WALKVECTOR(Cli::Cl_t,pC->Cl_v,i) {     // Walk the clause list
   if (sCl=="name") { par->Post(247,sCo,sCl,sPa);  continue;  }
   if (sCl=="pars") { par->pCmLoad->Show(f);       continue;  }
   if (sCl=="path") { par->pCmPath->Show(f);       continue;  }
-  if (sCl=="plac") { par->Post(247,sCo,sCl,sPa);  continue;  }
+  if (sCl=="plac") { Cm_Plac(f);                  continue;  }
   if (sCl=="syst") {
     par->pPmap->Show(f);
     dynamic_cast<Root *>(par)->pOC->Show(f);

--- a/Source/OrchBase/Handlers/CmShow.h
+++ b/Source/OrchBase/Handlers/CmShow.h
@@ -17,6 +17,7 @@ public:
 virtual ~     CmShow();
 
 void          Cm_Engine(FILE*);
+void          Cm_Plac(FILE*);
 
 void          Dump(FILE * = stdout);
 unsigned      operator()(Cli *);

--- a/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.cpp
+++ b/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.cpp
@@ -1,10 +1,8 @@
 #include "SimulatedAnnealing.h"
 
-SimulatedAnnealing::SimulatedAnnealing(Placer* placer, bool disorder,
-                                       bool inPlace):
+SimulatedAnnealing::SimulatedAnnealing(Placer* placer, bool disorder):
     Algorithm(placer),
-    disorder(disorder),
-    inPlace(inPlace)
+    disorder(disorder)
 {
     if (disorder) result.method = "sa";
     else result.method = "gc";
@@ -45,6 +43,12 @@ float SimulatedAnnealing::do_it(GraphI_t* gi)
 {
     std::string time = placer->timestamp();
 
+    /* Grab arguments, if any are set. */
+    bool inPlace = false;
+    if (placer->args.is_set("inplace"))
+        inPlace = placer->args.get_bool("inplace");
+
+    /* Generic setup. */
     std::string algorithmName;
     if (disorder) algorithmName = "simulated_annealing";
     else algorithmName = "gradientless_climber";

--- a/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.cpp
+++ b/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.cpp
@@ -46,12 +46,11 @@ float SimulatedAnnealing::do_it(GraphI_t* gi)
 
     /* Grab arguments, if any are set. */
     bool inPlace = false;
-    if (placer->args.is_set("inplace"))
-        inPlace = placer->args.get_bool("inplace");
+    if (placer->args.is_set("inpl")) inPlace = placer->args.get_bool("inpl");
 
     maxIteration = ITERATION_MAX_DEFAULT;
-    if (placer->args.is_set("iterations"))
-        maxIteration = placer->args.get_uint("iterations");
+    if (placer->args.is_set("iter"))
+        maxIteration = placer->args.get_uint("iter");
 
     /* Generic setup. */
     std::string algorithmName;

--- a/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.cpp
+++ b/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.cpp
@@ -82,13 +82,19 @@ float SimulatedAnnealing::do_it(GraphI_t* gi)
 
     /* If the caller requests an in-place anneal, check if the graph is
      * placed. If it's not, issue a warning. */
-    if (inPlace and
-        (placer->placedGraphs.find(gi) != placer->placedGraphs.end()))
+    std::map<GraphI_t*, Algorithm*>::iterator algorithmIt;
+    algorithmIt = placer->placedGraphs.find(gi);
+    if (inPlace and (algorithmIt == placer->placedGraphs.end()))
     {
         fprintf(log, "[W] Initial placement requested, but this graph "
                      "instance has not been placed.\n");
     }
-    else if (inPlace) fprintf(log, "[I] Annealing on existing placement.\n");
+    else if (inPlace)
+    {
+        fprintf(log, "[I] Annealing on an existing placement.\n");
+        /* Clear old algorithm object. */
+        delete algorithmIt->second;
+    }
     else
     {
         /* Initial placement using smart-random. Note that we rely on this

--- a/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.cpp
+++ b/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.cpp
@@ -25,13 +25,14 @@ float SimulatedAnnealing::acceptance_probability(float fitnessBefore,
 
 /* Computes the disorder value as a function of the iteration number, between
  * half (at iteration=0) and zero (lim iteration ->inf). Decrease must be
- * monotonic. For now, it's a simple exponential decay.
+ * monotonic. For now, it's a simple exponential decay with half life of a
+ * third of the number of iterations (thats what the factor 3 is for).
  *
  * In the case of simulated annealing that only accepts better
  * configurations, disorder is always zero. */
 float SimulatedAnnealing::compute_disorder()
 {
-    if (disorder) return 0.5 * exp(DISORDER_DECAY * iteration);
+    if (disorder) return 0.5 * exp(log(0.5) * 3 * iteration / maxIteration);
     else return 0;
 }
 
@@ -47,6 +48,10 @@ float SimulatedAnnealing::do_it(GraphI_t* gi)
     bool inPlace = false;
     if (placer->args.is_set("inplace"))
         inPlace = placer->args.get_bool("inplace");
+
+    maxIteration = ITERATION_MAX_DEFAULT;
+    if (placer->args.is_set("iterations"))
+        maxIteration = placer->args.get_uint("iterations");
 
     /* Generic setup. */
     std::string algorithmName;
@@ -443,7 +448,7 @@ float SimulatedAnnealing::do_it(GraphI_t* gi)
 /* Returns true if the termination condition holds, and false otherwise. It's
  * pretty simple - for now we're just counting iterations - but this probably
  * will change as we become more curious. */
-bool SimulatedAnnealing::is_finished(){return iteration >= ITERATION_MAX;}
+bool SimulatedAnnealing::is_finished(){return iteration >= maxIteration;}
 
 /* Performs the selection operation for simulated annealing. Arguments
  *

--- a/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.cpp
+++ b/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.cpp
@@ -84,19 +84,11 @@ float SimulatedAnnealing::do_it(GraphI_t* gi)
      * placed. If it's not, issue a warning. */
     std::map<GraphI_t*, Algorithm*>::iterator algorithmIt;
     algorithmIt = placer->placedGraphs.find(gi);
-    if (inPlace and (algorithmIt == placer->placedGraphs.end()))
+    if (algorithmIt == placer->placedGraphs.end())  /* Not placed. */
     {
-        fprintf(log, "[W] Initial placement requested, but this graph "
-                     "instance has not been placed.\n");
-    }
-    else if (inPlace)
-    {
-        fprintf(log, "[I] Annealing on an existing placement.\n");
-        /* Clear old algorithm object. */
-        delete algorithmIt->second;
-    }
-    else
-    {
+        if (inPlace) fprintf(log, "[W] Initial placement requested, but this "
+                                  "graph instance has not been placed.\n");
+
         /* Initial placement using smart-random. Note that we rely on this
          * being a valid placement in order for this algorithm to select across
          * the domain. (MLV never writes broken code! >_>). If it doesn't work,
@@ -110,6 +102,11 @@ float SimulatedAnnealing::do_it(GraphI_t* gi)
             ThreadFilling otherInitialAlgorithm = ThreadFilling(placer);
             otherInitialAlgorithm.do_it(gi);
         }
+    }
+    else if (inPlace)  /* Was already placed, as user intended. */
+    {
+        fprintf(log, "[I] Annealing on an existing placement.\n");
+        delete algorithmIt->second;  /* Clear old algorithm object. */
     }
 
     /* Compute fitness of initial placement. */

--- a/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.h
+++ b/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.h
@@ -21,10 +21,11 @@ class HardwareIterator;
 class SimulatedAnnealing: public Algorithm
 {
 public:
-    SimulatedAnnealing(Placer* placer, bool disorder=true);
+    SimulatedAnnealing(Placer* placer, bool disorder=true, bool inPlace=true);
 
-    unsigned iteration;
     bool disorder;
+    bool inPlace;
+    unsigned iteration;
 
     /* Holds, for each device type, which cores are valid for placement of
      * devices of that type. */

--- a/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.h
+++ b/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.h
@@ -21,10 +21,9 @@ class HardwareIterator;
 class SimulatedAnnealing: public Algorithm
 {
 public:
-    SimulatedAnnealing(Placer* placer, bool disorder=true, bool inPlace=false);
+    SimulatedAnnealing(Placer* placer, bool disorder=true);
 
     bool disorder;
-    bool inPlace;
     unsigned iteration;
 
     /* Holds, for each device type, which cores are valid for placement of

--- a/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.h
+++ b/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.h
@@ -21,7 +21,7 @@ class HardwareIterator;
 class SimulatedAnnealing: public Algorithm
 {
 public:
-    SimulatedAnnealing(Placer* placer, bool disorder=true, bool inPlace=true);
+    SimulatedAnnealing(Placer* placer, bool disorder=true, bool inPlace=false);
 
     bool disorder;
     bool inPlace;

--- a/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.h
+++ b/Source/OrchBase/Placement/Algorithms/SimulatedAnnealing.h
@@ -13,10 +13,10 @@ class HardwareIterator;
 #include "ThreadFilling.h"
 
 /* Naive end point. */
-#define ITERATION_MAX 100000000
+#define ITERATION_MAX_DEFAULT unsigned(1e8)
 
 /* Exponential decay with half life of a third of the number of iterations. */
-#define DISORDER_DECAY log(0.5) / (ITERATION_MAX / 3.0)
+#define DISORDER_DECAY
 
 class SimulatedAnnealing: public Algorithm
 {
@@ -25,6 +25,7 @@ public:
 
     bool disorder;
     unsigned iteration;
+    unsigned maxIteration;  /* Set in do_it */
 
     /* Holds, for each device type, which cores are valid for placement of
      * devices of that type. */

--- a/Source/OrchBase/Placement/Exceptions/InvalidArgumentException.h
+++ b/Source/OrchBase/Placement/Exceptions/InvalidArgumentException.h
@@ -1,0 +1,18 @@
+#ifndef __ORCHESTRATOR_SOURCE_ORCHBASE_PLACEMENT_EXCEPTIONS_INVALIDARGUMENTEXCEPTION_H
+#define __ORCHESTRATOR_SOURCE_ORCHBASE_PLACEMENT_EXCEPTIONS_INVALIDARGUMENTEXCEPTION_H
+
+/* Describes an exception that is to be thrown if either:
+ * - the argument name is invalid, or
+ * - the argument name is valid but the value is invalid, or
+ * - an algorithm has been given an argument that doesn't make sense. */
+
+#include "OrchestratorException.h"
+
+class InvalidArgumentException: public OrchestratorException
+{
+public:
+    InvalidArgumentException(std::string message):
+        OrchestratorException(message){};
+};
+
+#endif

--- a/Source/OrchBase/Placement/PlaceArgs.cpp
+++ b/Source/OrchBase/Placement/PlaceArgs.cpp
@@ -98,13 +98,13 @@ void PlaceArgs::set(std::string name, std::string value)
 void PlaceArgs::setup()
 {
     /* ho ho ho */
-    validAlgs["sa"].insert("iterations");
-    validAlgs["sa"].insert("inplace");
-    validAlgs["gc"].insert("iterations");
-    validAlgs["gc"].insert("inplace");
-
     validTypes["inpl"] = "bool";  /* Inplace */
     validTypes["iter"] = "unsigned";  /* Iterations */
+
+    validAlgs["sa"].insert("iter");
+    validAlgs["sa"].insert("inpl");
+    validAlgs["gc"].insert("iter");
+    validAlgs["gc"].insert("inpl");
 }
 
 /* Given the name of an algorithm, checks the all set arguments. Throws an

--- a/Source/OrchBase/Placement/PlaceArgs.cpp
+++ b/Source/OrchBase/Placement/PlaceArgs.cpp
@@ -47,7 +47,7 @@ unsigned PlaceArgs::get_uint(std::string name)
             dformat("Argument '%s' has not been set.", name.c_str()));
 
     /* Get it and decode it. */
-    return str2uint(name);
+    return str2uint(args[name]);
 }
 
 /* Sets the value of an argument, doing some validation on the type. */

--- a/Source/OrchBase/Placement/PlaceArgs.cpp
+++ b/Source/OrchBase/Placement/PlaceArgs.cpp
@@ -135,7 +135,10 @@ void PlaceArgs::validate_args(std::string algName)
             else comma = true;
             errStream << *badArgIt;
         }
-        errStream << "' are not valid for the '" << algName << "' algorithm.";
+        if (badArgs.size() == 1) errStream << "' is ";
+        else errStream << "' are ";
+        errStream << "not valid for the '" << algName << "' algorithm. "
+                  << "Clearing arguments.";
         clear();
         throw InvalidArgumentException(errStream.str());
     }

--- a/Source/OrchBase/Placement/PlaceArgs.cpp
+++ b/Source/OrchBase/Placement/PlaceArgs.cpp
@@ -108,7 +108,8 @@ void PlaceArgs::setup()
 }
 
 /* Given the name of an algorithm, checks the all set arguments. Throws an
- * InvalidArgumentException if an argument doesn't match for this algorithm. */
+ * InvalidArgumentException, and clears all set arguments, if an argument
+ * doesn't match for this algorithm. */
 void PlaceArgs::validate_args(std::string algName)
 {
     /* Search */
@@ -135,6 +136,7 @@ void PlaceArgs::validate_args(std::string algName)
             errStream << *badArgIt;
         }
         errStream << "' are not valid for the '" << algName << "' algorithm.";
+        clear();
         throw InvalidArgumentException(errStream.str());
     }
 }

--- a/Source/OrchBase/Placement/PlaceArgs.cpp
+++ b/Source/OrchBase/Placement/PlaceArgs.cpp
@@ -103,8 +103,8 @@ void PlaceArgs::setup()
     validAlgs["gc"].insert("iterations");
     validAlgs["gc"].insert("inplace");
 
-    validTypes["inplace"] = "bool";
-    validTypes["iterations"] = "unsigned";
+    validTypes["inpl"] = "bool";  /* Inplace */
+    validTypes["iter"] = "unsigned";  /* Iterations */
 }
 
 /* Given the name of an algorithm, checks the all set arguments. Throws an

--- a/Source/OrchBase/Placement/PlaceArgs.cpp
+++ b/Source/OrchBase/Placement/PlaceArgs.cpp
@@ -1,0 +1,140 @@
+/* Defines the placement argument-holder (see the accompanying header for
+ * further information). */
+
+#include <sstream>
+
+#include "PlaceArgs.h"
+#include "dprintf.h"
+#include "flat.h"
+
+/* Gets the value of a boolean argument. Throws an InvalidArgumentException
+ * if the argument is not set, does not exist, or is not a boolean argument. */
+bool PlaceArgs::get_bool(std::string name)
+{
+    /* Is the argument boolean? */
+    std::map<std::string, std::string>::iterator typeIt;
+    typeIt = validTypes.find(name);
+    InvalidArgumentException exc = InvalidArgumentException(
+        dformat("Invalid argument '%s' is not boolean.", name.c_str()));
+    if (typeIt == validTypes.end()) throw exc;
+    if (typeIt->second != "bool") throw exc;
+
+    /* Is the value set? */
+    if (args[name].empty())
+        throw InvalidArgumentException(
+            dformat("Argument '%s' has not been set.", name.c_str()));
+
+    /* Get it and decode it. */
+    return (args[name] == "True" or args[name] == "true");
+}
+
+/* Gets the value of an unsigned argument. Throws an InvalidArgumentException
+ * if the argument is not set, does not exist, or is not an unsigned
+ * argument. */
+unsigned PlaceArgs::get_uint(std::string name)
+{
+    /* Is the argument unsigned? */
+    std::map<std::string, std::string>::iterator typeIt;
+    typeIt = validTypes.find(name);
+    InvalidArgumentException exc = InvalidArgumentException(
+        dformat("Invalid argument '%s' is not unsigned.", name.c_str()));
+    if (typeIt == validTypes.end()) throw exc;
+    if (typeIt->second != "unsigned") throw exc;
+
+    /* Is the value set? */
+    if (args[name].empty())
+        throw InvalidArgumentException(
+            dformat("Argument '%s' has not been set.", name.c_str()));
+
+    /* Get it and decode it. */
+    return str2uint(name);
+}
+
+/* Sets the value of an argument, doing some validation on the type. */
+void PlaceArgs::set(std::string name, std::string value)
+{
+    /* Is the argument sane? */
+    std::map<std::string, std::string>::iterator typeIt;
+    typeIt = validTypes.find(name);
+    if (typeIt == validTypes.end())
+        throw InvalidArgumentException(
+            dformat("Invalid argument '%s'.", name.c_str()));
+
+    /* Iterate through each type, and do some validation. */
+    if (typeIt->second == "bool")
+    {
+        if (value != "true" and value != "false" and
+            value != "True" and value != "False")
+        {
+            throw InvalidArgumentException(
+                dformat("Invalid value '%s' for argument '%s' (it should be a "
+                        "boolean).",
+                        value.c_str(), name.c_str()));
+        }
+    }
+
+    if (typeIt->second == "unsigned")
+    {
+        /* Go through each character in the string until you hit a
+         * non-digit. If we encounter any non-digits, or if the string is
+         * empty, throw a wobbly. */
+        std::string::const_iterator valIt = value.begin();
+        while (valIt != value.end() and std::isdigit(*valIt)) valIt++;
+        if (valIt != value.end() or value.empty())
+        {
+            throw InvalidArgumentException(
+                dformat("Invalid value '%s' for argument '%s' (it should be "
+                        "unsigned).",
+                        value.c_str(), name.c_str()));
+        }
+    }
+
+    /* If we're past validation, set the value. */
+    args[name] = value;
+}
+
+/* Sets up the `validAlgs` and `validTypes` map. These maps don't change for as
+ * long as this PlaceArgs exists. */
+void PlaceArgs::setup()
+{
+    /* ho ho ho */
+    validAlgs["sa"].insert("iterations");
+    validAlgs["sa"].insert("inplace");
+    validAlgs["gc"].insert("iterations");
+    validAlgs["gc"].insert("inplace");
+
+    validTypes["inplace"] = "bool";
+    validTypes["iterations"] = "unsigned";
+}
+
+/* Given the name of an algorithm, checks the all set arguments. Throws an
+ * InvalidArgumentException if an argument doesn't match for this algorithm. */
+void PlaceArgs::validate_args(std::string algName)
+{
+    /* Search */
+    std::set<std::string> badArgs;
+    std::map<std::string, std::string>::iterator setArgIt;
+    for (setArgIt = args.begin(); setArgIt != args.end(); setArgIt++)
+    {
+        if (validAlgs[algName].find(setArgIt->first) ==
+            validAlgs[algName].end()) badArgs.insert(setArgIt->first);
+    }
+
+    /* Report */
+    if (badArgs.size() > 0)
+    {
+        std::stringstream errStream;
+        if (badArgs.size() > 1) errStream << "Arguments '";
+        else errStream << "Argument '";
+        std::set<std::string>::iterator badArgIt;
+        bool comma = false;
+        for (badArgIt = badArgs.begin(); badArgIt != badArgs.end(); badArgIt++)
+        {
+            if (comma) errStream << ", ";
+            else comma = true;
+            errStream << *badArgIt;
+        }
+        errStream << "' are not valid for the '" << algName << "' algorithm.";
+        throw InvalidArgumentException(errStream.str());
+    }
+}

--- a/Source/OrchBase/Placement/PlaceArgs.h
+++ b/Source/OrchBase/Placement/PlaceArgs.h
@@ -1,0 +1,43 @@
+#ifndef __ORCHESTRATOR_SOURCE_ORCHBASE_PLACEMENT_PLACEARGS_H
+#define __ORCHESTRATOR_SOURCE_ORCHBASE_PLACEMENT_PLACEARGS_H
+
+/* Holds arguments for placement algorithms. Basically a use of the properties
+ * pattern.
+ *
+ * Some arguments can only be applied to certain algorithms, but we won't know
+ * which algorithm the arguments will be applied to until they've all been
+ * staged. */
+
+#include <map>
+#include <set>
+#include <string>
+
+#include "InvalidArgumentException.h"
+
+class PlaceArgs
+{
+public:
+    PlaceArgs(){setup();}
+    void clear(){args.clear();}
+
+    /* Getters for arguments of each type. */
+    bool get_bool(std::string name);
+    unsigned get_uint(std::string name);
+
+    bool is_set(std::string name){return args.find(name) != args.end();}
+    void set(std::string name, std::string value);
+    void setup();
+    void validate_args(std::string algName);
+
+private:
+    /* Holds currently-stored arguments from the operator. */
+    std::map<std::string, std::string> args;
+
+    /* Maps algorithms to valid arguments. "Static" after `setup` is called. */
+    std::map<std::string, std::set<std::string> > validAlgs;
+
+    /* Maps arguments to 'types'. "Static" after `setup` is called. */
+    std::map<std::string, std::string> validTypes;
+};
+
+#endif

--- a/Source/OrchBase/Placement/PlaceArgs.h
+++ b/Source/OrchBase/Placement/PlaceArgs.h
@@ -27,11 +27,12 @@ public:
 
     bool is_set(std::string name){return args.find(name) != args.end();}
     void set(std::string name, std::string value);
-    void setup();
     std::map<std::string, std::string>::size_type size(){return args.size();}
     void validate_args(std::string algName);
 
 private:
+    void setup();
+
     /* Holds currently-stored arguments from the operator. */
     std::map<std::string, std::string> args;
 

--- a/Source/OrchBase/Placement/PlaceArgs.h
+++ b/Source/OrchBase/Placement/PlaceArgs.h
@@ -28,6 +28,7 @@ public:
     bool is_set(std::string name){return args.find(name) != args.end();}
     void set(std::string name, std::string value);
     void setup();
+    std::map<std::string, std::string>::size_type size(){return args.size();}
     void validate_args(std::string algName);
 
 private:

--- a/Source/OrchBase/Placement/PlaceArgs.h
+++ b/Source/OrchBase/Placement/PlaceArgs.h
@@ -18,6 +18,7 @@ class PlaceArgs
 {
 public:
     PlaceArgs(){setup();}
+    void copy_to(std::map<std::string, std::string>& copy){copy = args;}
     void clear(){args.clear();}
 
     /* Getters for arguments of each type. */

--- a/Source/OrchBase/Placement/Placer.cpp
+++ b/Source/OrchBase/Placement/Placer.cpp
@@ -1161,6 +1161,9 @@ float Placer::place(GraphI_t* gi, Algorithm* algorithm)
     /* Run the algorithm on the application graph instance. */
     float score = algorithm->do_it(gi);
 
+    /* Clear input arguments. */
+    args.clear();
+
     /* Check placement integrity, throwing if there's a problem. */
     check_integrity(gi, algorithm);
 

--- a/Source/OrchBase/Placement/Placer.cpp
+++ b/Source/OrchBase/Placement/Placer.cpp
@@ -1139,9 +1139,7 @@ float Placer::place(GraphI_t* gi, Algorithm* algorithm)
      * NB: This supervisor binary is not mapped to boxes (because for now,
      * nobody actually cares). Later on, graph instances will need a map of box
      * keys to supervisor values, for when supervisors differ across boxes. */
-    gi->pSupI = new P_super;
-
-
+    if (gi->pSupI == PNULL) gi->pSupI = new P_super;
     return score;
 }
 
@@ -1413,6 +1411,7 @@ void Placer::unplace(GraphI_t* gi, bool andConstraints)
 
     /* No more supervisor. */
     delete gi->pSupI;
+    gi->pSupI = PNULL;
 }
 
 /* Updates the software addresses of each device in an application graph

--- a/Source/OrchBase/Placement/Placer.cpp
+++ b/Source/OrchBase/Placement/Placer.cpp
@@ -780,6 +780,13 @@ void Placer::dump_diagnostics(GraphI_t* gi, const char* path)
     out << "startTime:" << result->startTime << std::endl;
     out << "endTime:" << result->endTime << std::endl;
     out << "score:" << result->score << std::endl;
+
+    /* Args at the end, as key:value pairs. */
+    out << "argCount:" << result->args.size() << std::endl;
+    std::map<std::string, std::string>::iterator argIt;
+    for (argIt = result->args.begin(); argIt != result->args.end(); argIt++)
+        out << argIt->first << ":" << argIt->second << std::endl;
+
     out.close();
 }
 
@@ -1161,7 +1168,9 @@ float Placer::place(GraphI_t* gi, Algorithm* algorithm)
     /* Run the algorithm on the application graph instance. */
     float score = algorithm->do_it(gi);
 
-    /* Clear input arguments. */
+    /* Write input arguments to the algorithm's result object, then clear
+     * them. */
+    args.copy_to(algorithm->result.args);
     args.clear();
 
     /* Check placement integrity, throwing if there's a problem. */

--- a/Source/OrchBase/Placement/Placer.cpp
+++ b/Source/OrchBase/Placement/Placer.cpp
@@ -1109,7 +1109,7 @@ float Placer::place(GraphI_t* gi, Algorithm* algorithm)
     /* Complain if the application graph instance has already been placed (by
      * memory address). Don't do this if an in-place approach is requested. */
     bool inPlace = false;
-    if (args.is_set("inplace")) inPlace = args.get_bool("inplace");
+    if (args.is_set("inpl")) inPlace = args.get_bool("inpl");
 
     if (placedGraphs.find(gi) != placedGraphs.end() and !inPlace)
     {

--- a/Source/OrchBase/Placement/Placer.cpp
+++ b/Source/OrchBase/Placement/Placer.cpp
@@ -60,6 +60,40 @@ Algorithm* Placer::algorithm_from_string(std::string colloquialDescription)
     return output;
 }
 
+/* A simple filter:
+ *
+ * - if `unknown` is the name of an algorithm, returns true and sets
+ *   `isAlgorithm` to true.
+ *
+ * - if `unknown` is the name of an argumetn, returns true and sets
+ *   `isAlgorithm` to false.
+ *
+ * - if `unknown` is neither an algorithm nor argument, returns false and does
+ *   not set `isAlgorithm`. */
+bool Placer::algorithm_or_argument(std::string unknown, bool& isAlgorithm)
+{
+    if (unknown == "app" or   /* Default */
+        unknown == "buck" or  /* Thread filling */
+        unknown == "gc" or    /* Gradient climber */
+        unknown == "link" or  /* Default */
+        unknown == "rand" or  /* Smart-Random */
+        unknown == "sa" or    /* Simulated Annealing */
+        unknown == "tfil")    /* Thread filling */
+    {
+        isAlgorithm = true;
+        return true;
+    }
+
+    else if (unknown == "inpl" or  /* In place */
+             unknown == "iter")    /* Maximum number of iterations */
+    {
+        isAlgorithm = false;
+        return true;
+    }
+
+    return false;
+}
+
 /* Returns true if all core pairs (or single cores, if that's how the model is
  * configured) have devices of one (or zero) type mapped to them, and false
  * otherwise. Arguments:

--- a/Source/OrchBase/Placement/Placer.cpp
+++ b/Source/OrchBase/Placement/Placer.cpp
@@ -1102,9 +1102,16 @@ float Placer::place(GraphI_t* gi, Algorithm* algorithm)
         "defining an engine pointer in the placer. If you're running this "
         "from OrchBase, how did you get here?");
 
+    /* Check that the options set by the operator make sense for the algorithm
+     * being used. May throw. */
+    args.validate_args(algorithm->result.method);
+
     /* Complain if the application graph instance has already been placed (by
-     * memory address). */
-    if (placedGraphs.find(gi) != placedGraphs.end())
+     * memory address). Don't do this if an in-place approach is requested. */
+    bool inPlace = false;
+    if (args.is_set("inplace")) inPlace = args.get_bool("inplace");
+
+    if (placedGraphs.find(gi) != placedGraphs.end() and !inPlace)
     {
         delete algorithm;
         throw AlreadyPlacedException(dformat(

--- a/Source/OrchBase/Placement/Placer.h
+++ b/Source/OrchBase/Placement/Placer.h
@@ -89,6 +89,10 @@ public:
     /* Staged arguments for the next algorithm. */
     PlaceArgs args;
 
+    /* Identify whether an input string is an algorithm or an argument. Also
+     * see the private algorithm_from_string method. */
+    bool algorithm_or_argument(std::string unknown, bool& isAlgorithm);
+
     /* Check integrity of a placed graph instance. */
     void check_integrity(GraphI_t* gi, Algorithm* algorithm);
     bool are_all_core_pairs_device_locked(GraphI_t* gi,
@@ -154,7 +158,9 @@ public:
     std::string timestamp();
 
 private:
-    Algorithm* algorithm_from_string(std::string);
+    Algorithm* algorithm_from_string(std::string);  /* Also see the public
+                                                     * algorithm_or_argument
+                                                     * method. */
     void update_gi_to_cores_map(GraphI_t* gi);
 
     void populate_device_to_graph_key_map(GraphI_t* gi);

--- a/Source/OrchBase/Placement/Placer.h
+++ b/Source/OrchBase/Placement/Placer.h
@@ -45,6 +45,7 @@ struct Result;
 #include "GraphI_t.h"
 #include "HardwareModel.h"
 #include "OSFixes.hpp"
+#include "PlaceArgs.h"
 #include "UniqueDevT.h"
 
 #define THREAD_LOADING_SCALING_FACTOR 0.01
@@ -84,6 +85,9 @@ public:
     /* Path to write output files to (e.g. dumps, results). At its best with a
      * trailing slash (yay C++98) */
     std::string outFilePath;
+
+    /* Staged arguments for the next algorithm. */
+    PlaceArgs args;
 
     /* Check integrity of a placed graph instance. */
     void check_integrity(GraphI_t* gi, Algorithm* algorithm);

--- a/Source/OrchBase/Placement/Result.h
+++ b/Source/OrchBase/Placement/Result.h
@@ -6,10 +6,12 @@
  *
  * See the placement documentation for further information. */
 
+#include <map>
 #include <string>
 
 struct Result
 {
+    std::map<std::string, std::string> args;
     unsigned maxDevicesPerThread;
     float maxEdgeCost;
     std::string method;


### PR DESCRIPTION
Do not review until #185 has been merged in. Resolves #184.

This changeset introduces an argument-holding object, `Placer::args`, which holds arguments staged to operate on the next placement algorithm that is invoked.

See the documentation PR at https://github.com/POETSII/orchestrator-documentation/pull/12 for an explanation.

Tested by using the ddos supervisor example (because it's got a lot of devices in it), by:

 - Setting an argument, running a non-annealing algorithm, and verifying that the Orchestrator complains.
 - After the above error, running a non-annealing algorithm, and verifying the annealing output (as the argument structure is cleared).
 - Running a non-annealing algorithm (bucket-filling), setting the in-place argument, running annealing, and verifying that the placement output (via a dump) has been annealed.
 - As above, but also setting the iteration value to zero, and verifying that the output state is untouched.
 - As above, but also setting the iteration value to ten, and verifying that the output state has fewer than ten alterations (but more than one).

All of the above have been run under valgrind (no errors), and in "all" mode. 