### PR TITLE
Rudimentary rlwrap support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Build/gcc/Objects
 Build/gcc/Dependency_lists
 Output/
 orchestrate.sh
+.orch_history
 
 # Ignore .bak extensions created by winmerge
 *.bak

--- a/Build/gcc/Resources/orchestrate_template.sh
+++ b/Build/gcc/Resources/orchestrate_template.sh
@@ -116,7 +116,12 @@ done
 
 # Run the launcher from the build directory.
 pushd "{{ EXECUTABLE_DIR }}" > /dev/null
-./orchestrate /p = "\"$INTERNAL_LIB_PATH\"" $ARGS
+if ! command -v rlwrap &> /dev/null; then
+    ./orchestrate /p = "\"$INTERNAL_LIB_PATH\"" $ARGS
+else
+    rlwrap --remember --history-filename ../.orch_history \
+        ./orchestrate /p = "\"$INTERNAL_LIB_PATH\"" $ARGS
+fi
 if [ $GNU_HELP -eq 1 ]; then
     printf "\nNote that there is limited support for short-form GNU-style switches (e.g. '-h -f FILE').\n"
 fi


### PR DESCRIPTION
Resolves #189 

Introduces `rlwrap` support for computers that have it installed. Tested on my machine by installing/uninstalling `rlwrap`, running `test /echo = "Cheers DBT"`, and verifying that the memory persists between sessions if `rlwrap` is installed.

See also: https://github.com/POETSII/orchestrator-documentation/pull/14.