### PR TITLE
Handle unimplemented Supervisor input pins more gracefully

### DIFF
--- a/Config/OrchestratorMessages.ocfg
+++ b/Config/OrchestratorMessages.ocfg
@@ -150,6 +150,7 @@
 251(W) : "... integrity check on %s generated %s(%s) errors(warnings) in %s msecs"
 252(I) : "Starting integrity check on application %s"
 253(I) : "System wide integrity check took %s ms"
+254(E) : "Attempt to use unimplemented functionality in %s block: %s on line %s"
 
 300(W) : "Unable to invoke the placement system - no hardware model has been loaded."
 301(W) : "Unable to identify graph instance '%s' (the first parameter should be of the form 'APPNAME::GRAPHINSTANCENAME')."

--- a/Source/OrchBase/XMLProcessing/DS_XML.cpp
+++ b/Source/OrchBase/XMLProcessing/DS_XML.cpp
@@ -468,7 +468,7 @@ WALKVECTOR(xnode *,pn->vnode,i) {
     // Uninplemented functionality: throw an E
     case cInputPin         : //Intentional fall-through
     case cOutputPin        : par->Post(254,"SupervisorType",(*i)->ename,
-                                int2str(pn->lin));          break;
+                                int2str(pn->lin));                    break;
     // Paranoid U catch-all
     default                : par->Post(998,__FILE__,int2str(__LINE__),
                                        (*i)->ename);

--- a/Source/OrchBase/XMLProcessing/DS_XML.cpp
+++ b/Source/OrchBase/XMLProcessing/DS_XML.cpp
@@ -464,6 +464,12 @@ WALKVECTOR(xnode *,pn->vnode,i) {
     case cOnCTL            : pS->pOnCTL   = _CFrag(*i);               break;
     case cOnInit           : pS->pOnInit = _CFrag(*i);                break;
     case cMetaData         : pS->Meta_v.push_back(_Meta(*i));         break;
+    
+    // Uninplemented functionality: throw an E
+    case cInputPin         : //Intentional fall-through
+    case cOutputPin        : par->Post(254,"SupervisorType",(*i)->ename,
+                                int2str(pn->lin));          break;
+    // Paranoid U catch-all
     default                : par->Post(998,__FILE__,int2str(__LINE__),
                                        (*i)->ename);
   }


### PR DESCRIPTION
Quick and simple fix to more gracefully handle the (currently) unimplemented `InputPin` and `OutputPin` elements under a `SupervisorType` that are valid in the XML.

Instead of the catch-all 998 Unrecoverable, this now posts a 254 Error for both pin types. 

Tested with a selection of valid and invalid XMLs.

Fixes #169 