### PR TITLE
Disable RTCL, and log when it's disabled in debug mode.

### DIFF
--- a/Source/Launcher/LauncherMain.cpp
+++ b/Source/Launcher/LauncherMain.cpp
@@ -131,14 +131,19 @@ void BuildCommand(bool useMotherships, std::string internalPath,
                                                                << " ";
     *(hydraProcesses.back()) << localBinDir << "/" << execLogserver;
 
-    /* Clock */
-    hydraProcesses.push_back(new std::stringstream);
-    orderedHosts.push_back(ourHostname);
-    *(hydraProcesses.back()) << "-n 1 ";
-    if (gdbProcs[execClock]) *(hydraProcesses.back()) << execGdb << " ";
-    if (valgrindProcs[execClock]) *(hydraProcesses.back()) << execValgrind
-                                                           << " ";
-    *(hydraProcesses.back()) << localBinDir << "/" << execClock;
+    /* Clock - optionally disabled. */
+    if (USE_CLOCK)
+    {
+        hydraProcesses.push_back(new std::stringstream);
+        orderedHosts.push_back(ourHostname);
+        *(hydraProcesses.back()) << "-n 1 ";
+        if (gdbProcs[execClock]) *(hydraProcesses.back()) << execGdb << " ";
+        if (valgrindProcs[execClock]) *(hydraProcesses.back()) << execValgrind
+                                                               << " ";
+        *(hydraProcesses.back()) << localBinDir << "/" << execClock;
+    }
+    else DebugPrint("%sThe real-time clock is currently DISABLED.\n",
+                    debugHeader);
 
     /* Adding motherships... */
     if (useMotherships)

--- a/Source/Launcher/LauncherMain.h
+++ b/Source/Launcher/LauncherMain.h
@@ -16,6 +16,8 @@
 
 #include <stdlib.h>
 
+#define USE_CLOCK false
+
 namespace Launcher
 {
     const char* debugHeader = "[LAUNCHER] ";


### PR DESCRIPTION
Resolves #238. I reckon it's pretty self-explanatory. We still compile the clock though as part of the build process.