### PR TITLE
Scheduled exits

### DIFF
--- a/Config/OrchestratorMessages.ocfg
+++ b/Config/OrchestratorMessages.ocfg
@@ -45,6 +45,7 @@
 066(E) : "Exit trigger '%s' not defined. Ignoring."
 067(I) : "Exit trigger staged - will exit when the command queue is empty."
 068(I) : "Exit trigger hit - closing down the Orchestrator."
+069(I) : "Exit trigger staged - will exit when the next application is completely stopped."
 
 090(I) : "TEST|MSG received by UserO, payload component %s is %s"
 091(W) : "TEST|MSG received by UserO, addressed to unknown owner (%s)"

--- a/Config/OrchestratorMessages.ocfg
+++ b/Config/OrchestratorMessages.ocfg
@@ -43,6 +43,8 @@
 064(W) : "Application %s is not present in the database"
 065(I) : "Application file %s loaded in %s ms."
 066(E) : "Exit trigger '%s' not defined. Ignoring."
+067(I) : "Exit trigger staged - will exit when the command queue is empty."
+068(I) : "Exit trigger hit - closing down the Orchestrator."
 
 090(I) : "TEST|MSG received by UserO, payload component %s is %s"
 091(W) : "TEST|MSG received by UserO, addressed to unknown owner (%s)"

--- a/Config/OrchestratorMessages.ocfg
+++ b/Config/OrchestratorMessages.ocfg
@@ -42,6 +42,7 @@
 063(S) : "%s"
 064(W) : "Application %s is not present in the database"
 065(I) : "Application file %s loaded in %s ms."
+066(E) : "Exit trigger '%s' not defined. Ignoring."
 
 090(I) : "TEST|MSG received by UserO, payload component %s is %s"
 091(W) : "TEST|MSG received by UserO, addressed to unknown owner (%s)"

--- a/Config/OrchestratorMessages.ocfg
+++ b/Config/OrchestratorMessages.ocfg
@@ -44,7 +44,7 @@
 065(I) : "Application file %s loaded in %s ms."
 066(E) : "Exit trigger '%s' not defined. Ignoring."
 067(I) : "Exit trigger staged - will exit when the command queue is empty."
-068(I) : "Exit trigger hit - closing down the Orchestrator."
+068(I) : "Exit trigger hit - closing down the Orchestrator. The prompt is disabled."
 069(I) : "Exit trigger staged - will exit when the next application is completely stopped."
 
 090(I) : "TEST|MSG received by UserO, payload component %s is %s"

--- a/Source/OrchBase/Handlers/CmTest.cpp
+++ b/Source/OrchBase/Handlers/CmTest.cpp
@@ -44,6 +44,15 @@ void CmTest::Cm_Echo(Cli::Cl_t cl)
 
 //------------------------------------------------------------------------------
 
+void CmTest::Cm_Sleep(Cli::Cl_t cl)
+// Pass an unsigned integer, we kip for a bit. Pass something else, nothing
+// will happen (probably).
+{
+    OSFixes::sleep(str2uint(cl.Pa_v.begin()->Concatenate()));
+}
+
+//------------------------------------------------------------------------------
+
 void CmTest::Dump(FILE * fp)
 {
 fprintf(fp,"CmTest+++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n");
@@ -73,6 +82,7 @@ if (pC==0) return 0;                   // Paranoia
 WALKVECTOR(Cli::Cl_t,pC->Cl_v,i) {     // Walk the clause list
   string sCl = (*i).Cl;                // Pull out clause name
   if (strcmp(sCl.c_str(),"echo")==0) {Cm_Echo(*i); continue;}
+  if (strcmp(sCl.c_str(),"slee")==0) {Cm_Sleep(*i); continue;}
   par->Post(25,sCl,"test");           // Unrecognised clause
 }
 return 0;                              // Legitimate command exit

--- a/Source/OrchBase/Handlers/CmTest.h
+++ b/Source/OrchBase/Handlers/CmTest.h
@@ -17,6 +17,7 @@ public:
 virtual ~     CmTest();
 
 void          Cm_Echo(Cli::Cl_t);
+void          Cm_Sleep(Cli::Cl_t);
 
 void          Dump(FILE * = stdout);
 void          Show(FILE * = stdout);

--- a/Source/Root/Root.cpp
+++ b/Source/Root/Root.cpp
@@ -222,6 +222,7 @@ WALKVECTOR(Cli::Cl_t,pC->Cl_v,i) {
       else Post(66,p);
   }
   else Post(25,i->Cl,"exit");           // Unrecognised clause
+  return 0;
 }
                                        // Normal exit coming from batch?
 if (!pCmCall->stack.empty()&&(!exitOnEmpty)) {
@@ -243,7 +244,6 @@ Post(50,Sderived,int2str(Urank));      // Root is going anyway
 Pkt.Send(pL);
 
 return CommonBase::OnExit(&Pkt);           // Run the base class exit handler
-// return 1;                                 // Return closedown flag
 }
 
 //------------------------------------------------------------------------------

--- a/Source/Root/Root.cpp
+++ b/Source/Root/Root.cpp
@@ -51,7 +51,8 @@ for(;;)
   if (buf[0]==char(0)) break;          // ctrl-d in linux-land
   if (buf[0]==char(4)) break;          // ctrl-d in u$oft-land
 }
-// Tell the user we're leaving immediately.
+// Tell the user now that we're closing down. Note that the exit command will
+// trigger an exit via ProcCmnd (OnIdle), so we don't need to call CmExit here.
 Root::promptOn = false;
 printf("Exiting...\n");
 pthread_exit(NULL);                    // Kill the keyboard thread

--- a/Source/Root/Root.cpp
+++ b/Source/Root/Root.cpp
@@ -25,8 +25,7 @@ void * kb_func(void * pPar)
 // the MPI spinner.
 {
 int len = 0;                           // Characters in buffer
-for(;;)
-{
+for(;;) {
   if (len==0) Root::Prompt();          // Console prompt
   static const unsigned SIZE = 512;
   char buf[SIZE];

--- a/Source/Root/Root.cpp
+++ b/Source/Root/Root.cpp
@@ -216,7 +216,11 @@ if (pC != PNULL) WALKVECTOR(Cli::Cl_t,pC->Cl_v,i) {
   {
       string p = i->GetP(0);
       if (p.empty()) Post(47,i->Cl,"exit","1");
-      if (p=="end") exitOnEmpty = true;
+      if (p=="end")
+      {
+          exitOnEmpty = true;
+          Post(67);
+      }
       else Post(66,p);
   }
   else Post(25,i->Cl,"exit");           // Unrecognised clause
@@ -327,6 +331,11 @@ else                                   // Nothing there, check exit conditions
   // Exit on empty queue, if staged.
   if (exitOnEmpty)
   {
+      // Post before we go. Delay to ensure this gets there before the exit
+      // message.
+      Post(68);
+      OSFixes::sleep(100);
+
       // Message ourselves to get out of MPISpinner.
       PMsg_p exitMsg;
       exitMsg.Key(Q::EXIT);
@@ -335,10 +344,6 @@ else                                   // Nothing there, check exit conditions
 
       // Cancel the keyboard thread (breaks out of fgets).
       pthread_cancel(kb_thread);
-
-      // Tell the user we're leaving now.
-      Root::promptOn = false;
-      printf("Exiting...\n");
 
       // Send exit to other processes.
       CmExit(0);

--- a/Source/Root/Root.cpp
+++ b/Source/Root/Root.cpp
@@ -25,7 +25,8 @@ void * kb_func(void * pPar)
 // the MPI spinner.
 {
 int len = 0;                           // Characters in buffer
-for(;;) {                              // Superloop
+while(!(static_cast<Root*>(pPar)->exitTriggered))  // exit from elsewhere
+{
   if (len==0) Root::Prompt();          // Console prompt
   static const unsigned SIZE = 512;
   char buf[SIZE];
@@ -49,8 +50,6 @@ for(;;) {                              // Superloop
   if (strcmp(buf,"exit")==0) break;    // "exit" typed
   if (buf[0]==char(0)) break;          // ctrl-d in linux-land
   if (buf[0]==char(4)) break;          // ctrl-d in u$oft-land
-  // "exit" from elsewhere
-  if (static_cast<Root*>(pPar)->exitTriggered) break;
 }
 // Tell the user we're leaving immediately.
 Root::promptOn = false;
@@ -329,6 +328,12 @@ else                                   // Nothing there, check exit conditions
 {
   // Exit on empty queue, if staged.
   if (exitOnEmpty) exitTriggered = true;
+
+  // Message ourselves to get out of MPISpinner.
+  PMsg_p exitMsg;
+  exitMsg.Key(Q::EXIT);
+  exitMsg.Src(Urank);
+  exitMsg.Send(Urank);
 }
 return;
 }

--- a/Source/Root/Root.cpp
+++ b/Source/Root/Root.cpp
@@ -221,6 +221,11 @@ if (pC != PNULL) WALKVECTOR(Cli::Cl_t,pC->Cl_v,i) {
           exitOnEmpty = true;
           Post(67);
       }
+      if (p=="stop")
+      {
+          exitOnStop = true;
+          Post(69);
+      }
       else Post(66,p);
   }
   else Post(25,i->Cl,"exit");           // Unrecognised clause

--- a/Source/Root/Root.h
+++ b/Source/Root/Root.h
@@ -64,8 +64,8 @@ struct injData_t {
 
 OrchConfig *                   pOC;
 
+pthread_t                      kb_thread;
 bool                           exitOnEmpty;   // exit /at = end
-bool                           exitTriggered; // Informing keyboard thread
 };
 
 //==============================================================================

--- a/Source/Root/Root.h
+++ b/Source/Root/Root.h
@@ -63,6 +63,9 @@ struct injData_t {
 }                              injData;
 
 OrchConfig *                   pOC;
+
+bool                           exitOnEmpty;   // exit /at = end
+bool                           exitTriggered; // Informing keyboard thread
 };
 
 //==============================================================================

--- a/Source/Root/Root.h
+++ b/Source/Root/Root.h
@@ -65,6 +65,7 @@ struct injData_t {
 OrchConfig *                   pOC;
 
 pthread_t                      kb_thread;
+bool                           exitOnStop;    // exit /at = stop
 bool                           exitOnEmpty;   // exit /at = end
 };
 

--- a/Source/Root/Root.h
+++ b/Source/Root/Root.h
@@ -64,8 +64,9 @@ struct injData_t {
 OrchConfig *                   pOC;
 
 pthread_t                      kb_thread;
-bool                           exitOnStop;    // exit /at = stop
 bool                           exitOnEmpty;   // exit /at = end
+bool                           exitOnStop;    // exit /at = stop
+bool                           appJustStopped;
 };
 
 //==============================================================================


### PR DESCRIPTION
Resolves #256. To be reviewed only after #253 is approved (please let me know if I'm blocking you)!

This changeset:

 - Adds the `test /sleep` command, which causes the Root process of the Orchestrator to kip for a bit. The prompt remains active. Useful for forcing the Orchestrator to "do something" for a short while.
 - Adds the `exit /at` command to schedule exits to happen after certain events. Use `exit /at = end` to make the Orchestrator exit when the batch queue is empty (i.e. there are no more commands to run). Use `exit /at = stop` to make the Orchestrator exit the next time an application stops, either of it's own volition (using the Supervisor API), or because it was told to do so with `stop /app`. Scheduled exits are checked in Root's `OnIdle`, so they may be blocked by commands that take a long time to execute (like normal exits).
 - Does not change existing `exit` behaviour. You still can't use this one in a batch script.
 - Adds a new way out of the keyboard thread - `Root::OnIdle` can now `pthread_cancel` it (and does so when a scheduled exit triggers).

Note that scheduled exits can't be "unscheduled". Life's too short.

Documentation PR: https://github.com/POETSII/orchestrator-documentation/pull/20

By way of example, here's a batch script that runs an application, and causes the Orchestrator to close down once the application has stopped itself. The application in question uses the `stop_application` Supervisor API call (`test_superapi_stop`, in the Orchestrator examples repository):

```
exit /at = stop
load /app = +"test_superapi_stop.xml"
tlink /app = *
place /app = *
compose /app = *
deploy /app = *
init /app = *
run /app = *
```

Output:

```
$ ./orchestrate.sh -b test_superapi_stop.poets
POETS> 12:16:58.01:  20(I) The microlog for the command 'load /engine = "../Config/POETSHardwareOneBox.ocfg"' will be written to '../Output/Microlog/Microlog_2021_06_23T12_16_58p0.plog'.
POETS> 12:16:58.01: 140(I) Topology loaded from file ||../Config/POETSHardwareOneBox.ocfg||.
POETS> 12:16:58.01:  20(I) The microlog for the command 'call /file = "/home/mv1g18/repos/orchestrator/test_superapi_stop.poets"' will be written to '../Output/Microlog/Microlog_2021_06_
23T12_16_58p1.plog'.
POETS> 12:16:58.01:  20(I) The microlog for the command 'exit /at = stop' will be written to '../Output/Microlog/Microlog_2021_06_23T12_16_58p2.plog'.
POETS> 12:16:58.01:  69(I) Exit trigger staged - will exit when the next application is completely stopped.
POETS> 12:16:58.01:  20(I) The microlog for the command 'load /app = +test_superapi_stop.xml' will be written to '../Output/Microlog/Microlog_2021_06_23T12_16_58p3.plog'.
POETS> 12:16:58.01: 235(I) Application file ../test_superapi_stop.xml loading...
POETS> 12:16:58.01:  65(I) Application file ../test_superapi_stop.xml loaded in 19 ms.
POETS> 12:16:58.02:  20(I) The microlog for the command 'tlink /app = *' will be written to '../Output/Microlog/Microlog_2021_06_23T12_16_58p4.plog'.
POETS> 12:16:58.02: 234(I) Typelinking graph instance 'test_superapi_stop_instance'...
POETS> 12:16:58.02: 249(I) Successfully typelinked graph instance 'test_superapi_stop_instance'.
POETS> 12:16:58.02:  20(I) The microlog for the command 'place /app = *' will be written to '../Output/Microlog/Microlog_2021_06_23T12_16_58p5.plog'.
POETS> 12:16:58.02: 309(I) Attempting to place graph instance 'test_superapi_stop_instance' using the 'app' method...
POETS> 12:16:58.02: 302(I) Graph instance 'test_superapi_stop_instance' placed successfully.
POETS> 12:16:59.02:  20(I) The microlog for the command 'compose /app = *' will be written to '../Output/Microlog/Microlog_2021_06_23T12_16_58p6.plog'.
POETS> 12:16:59.02: 803(I) Composing graph instance 'test_superapi_stop_instance'...
POETS> 12:16:59.02: 804(I) Graph instance 'test_superapi_stop_instance' composed successfully.
POETS> 12:16:59.02:  20(I) The microlog for the command 'deploy /app = *' will be written to '../Output/Microlog/Microlog_2021_06_23T12_16_59p0.plog'.
POETS> 12:16:59.02: 184(I) Deployment of graph instance 'test_superapi_stop_instance' staged. Waiting for Mothership(s) to acknowledge receipt in the background.
POETS> 12:16:59.02:  20(I) The microlog for the command 'init /app = *' will be written to '../Output/Microlog/Microlog_2021_06_23T12_16_59p1.plog'.
POETS> 12:16:59.02: 187(I) Initialisation of graph instance 'test_superapi_stop_instance' staged. Waiting for Mothership(s) to acknowledge receipt in the background.
POETS> 12:16:59.02:  20(I) The microlog for the command 'run /app = *' will be written to '../Output/Microlog/Microlog_2021_06_23T12_16_59p2.plog'.
POETS> 12:16:59.02: 188(I) Run of graph instance 'test_superapi_stop_instance' staged. Waiting for Mothership(s) to acknowledge receipt in the background.
POETS> 12:17:13.29: 529(I) Mothership (rank 2): Deployment of application 'test_superapi_stop::test_superapi_stop_instance' (to this Mothership) complete.
POETS> 12:17:13.29: 530(I) Mothership (rank 2): Initialising fully-defined application 'test_superapi_stop::test_superapi_stop_instance'.
POETS> 12:17:13.29: 186(I) Application 'test_superapi_stop::test_superapi_stop_instance' successfully deployed on all Motherships it is mapped to.
POETS> 12:17:13.34: 531(I) Mothership (rank 2): Initialisation of application 'test_superapi_stop::test_superapi_stop_instance' (to this Mothership) complete.
POETS> 12:17:13.34: 186(I) Application 'test_superapi_stop::test_superapi_stop_instance' ready to start on all Motherships it is mapped to.
POETS> 12:17:13.34: 532(I) Mothership (rank 2): Starting (running) fully-initialised application 'test_superapi_stop::test_superapi_stop_instance'.
POETS> 12:17:13.34: 186(I) Application 'test_superapi_stop::test_superapi_stop_instance' running on all Motherships it is mapped to.
POETS> 12:17:13.36: 526(I) Mothership: Supervisor for application 'test_superapi_stop::test_superapi_stop_instance' has requested it to be stopped.
POETS> 12:17:13.36: 189(I) Stop of graph instance 'test_superapi_stop_instance' staged. Waiting for Mothership(s) to acknowledge receipt in the background.
POETS> 12:17:13.36: 533(I) Mothership (rank 2): Stopping application 'test_superapi_stop::test_superapi_stop_instance' (which has been started).
POETS> 12:17:13.37: 186(I) Application 'test_superapi_stop::test_superapi_stop_instance' stopped on all Motherships it is mapped to.
POETS> 12:17:13.37:  68(I) Exit trigger hit - closing down the Orchestrator. The prompt is disabled.
*control returns to calling process*
```

Another example that schedules an exit for the end of the batch script, then sleeps for five seconds:

```
exit /at = end
test /sleep = 5000
````

Output:

```
POETS> 14:48:49.00:  20(I) The microlog for the command 'load /engine = "../Config/POETSHardwareOneBox.ocfg"' will be written to '../Output/Microlog/Microlog_2021_06_23T14_48_49p0.plog'.
POETS> 14:48:49.00: 140(I) Topology loaded from file ||../Config/POETSHardwareOneBox.ocfg||.
POETS> 14:48:49.00:  20(I) The microlog for the command 'call /file = "/home/mark/repos/orchestrator/test.poets"' will be written to '../Output/Microlog/Microlog_2021_06_23T14_48_49p1.plog'.
POETS> 14:48:49.00:  20(I) The microlog for the command 'exit /at = end' will be written to '../Output/Microlog/Microlog_2021_06_23T14_48_49p2.plog'.
POETS> 14:48:49.00:  67(I) Exit trigger staged - will exit when the command queue is empty.
POETS> 14:48:54.00:  20(I) The microlog for the command 'test /sleep = 5000' will be written to '../Output/Microlog/Microlog_2021_06_23T14_48_49p3.plog'.
POETS> 14:48:54.01:  68(I) Exit trigger hit - closing down the Orchestrator. The prompt is disabled.
*control returns to calling process*
```
