### PR TITLE
Fix placement tests

### DIFF
--- a/Source/OrchBase/Handlers/CmPlac.cpp
+++ b/Source/OrchBase/Handlers/CmPlac.cpp
@@ -31,7 +31,6 @@ unsigned CmPlac::operator()(Cli* cli)
     {
         /* Call the appropriate method (from the first four characters of the
          * clause). */
-        bool isClauseValid = true;
         clauseRoot = clause->Cl.substr(0, 4);
 
         /* The following might not make sense, but before we enter our
@@ -63,6 +62,7 @@ unsigned CmPlac::operator()(Cli* cli)
         /* If nothing is appropriate, the operator is either setting an
          * argument or wanting to run a placement algorithm (or they're an
          * idiot). */
+        bool isClauseValid = false;
         if (isSomething)
         {
             if (isAlgorithm)

--- a/Source/OrchBase/Placement/Placer.cpp
+++ b/Source/OrchBase/Placement/Placer.cpp
@@ -79,6 +79,7 @@ bool Placer::algorithm_or_argument(std::string unknown, bool& isAlgorithm)
         unknown == "link" or  /* Default */
         unknown == "rand" or  /* Smart-Random */
         unknown == "sa" or    /* Simulated Annealing */
+        unknown == "spre" or  /* Spread filling */
         unknown == "tfil")    /* Thread filling */
     {
         isAlgorithm = true;

--- a/Tests/Placement/001/placement_test_001.poets
+++ b/Tests/Placement/001/placement_test_001.poets
@@ -1,3 +1,4 @@
+exit /at = end
 load /engine = "../placement_test_001.uif"
 load /app = +"placement_test_001.xml"
 tlink /app = *

--- a/Tests/Placement/002/placement_test_002.poets
+++ b/Tests/Placement/002/placement_test_002.poets
@@ -1,3 +1,4 @@
+exit /at = end
 load /engine = "../placement_test_002.uif"
 load /app = +"placement_test_002.xml"
 tlink /app = *

--- a/Tests/Placement/003/placement_test_003.poets
+++ b/Tests/Placement/003/placement_test_003.poets
@@ -1,3 +1,4 @@
+exit /at = end
 load /engine = "../placement_test_003.uif"
 load /app = +"placement_test_003.xml"
 tlink /app = *

--- a/Tests/Placement/004/placement_test_004.poets
+++ b/Tests/Placement/004/placement_test_004.poets
@@ -1,3 +1,4 @@
+exit /at = end
 load /engine = "../placement_test_004.uif"
 load /app = +"placement_test_004.xml"
 tlink /app = *

--- a/Tests/Placement/005/placement_test_005.poets
+++ b/Tests/Placement/005/placement_test_005.poets
@@ -1,3 +1,4 @@
+exit /at = end
 load /engine = "../placement_test_005.uif"
 load /app = +"placement_test_005.xml"
 tlink /app = *


### PR DESCRIPTION
This changeset

 - Re-enables the spread-filling algorithm, as the placement argument changes "turned it off".
 
 - Changes the placement tests to use scheduled exits.

 - Changes the spread-filling algorithm to respect the order in which device types and cores are declared, as opposed to using memory ordering (which is inconsistent).

Resolves #270 