### PR TITLE
Pins with no edges now execute OnSend

### DIFF
--- a/Source/Softswitch/src/softswitch_common.cpp
+++ b/Source/Softswitch/src/softswitch_common.cpp
@@ -399,28 +399,30 @@ inline uint32_t softswitch_onSend(ThreadCtxt_t* ThreadContext, volatile void* se
     volatile P_Pkt_Hdr_t* hdr = static_cast<volatile P_Pkt_Hdr_t*>(send_buf); // Header
 
     size_t hdrSize = p_hdr_size(); //Size of the header.
-
-    if(pin->numEdges > 0)     // Sanity check: make sure the pin has edges
+    
+    //--------------------------------------------------------------------------
+    // First target, need to run pin's OnSend. This is run whether there are
+    // targets or not.
+    //--------------------------------------------------------------------------
+    if(pin->idxEdges == 0)
     {
-        //--------------------------------------------------------------------------
-        // First target, need to run pin's OnSend.
-        //--------------------------------------------------------------------------
-        if(pin->idxEdges == 0)
-        {
-            char* pkt = const_cast<char*>(buf)+hdrSize; // Pointer to the packet, after headers, etc.
+        char* pkt = const_cast<char*>(buf)+hdrSize; // Pointer to the packet, after headers, etc.
 
 #ifdef BUFFERING_SOFTSWITCH
-            // Copy the packet from the packet buffer to the send slot
-            memcpy(pkt, ThreadContext->pktBuf[ThreadContext->rtsStart],
-                        pin->pinType->sz_pkt);
+        // Copy the packet from the packet buffer to the send slot
+        memcpy(pkt, ThreadContext->pktBuf[ThreadContext->rtsStart],
+                    pin->pinType->sz_pkt);
 #else
-            // Build the packet in the send slot
-            pin->pinType->Send_Handler(ThreadContext->properties, device, pkt);
-            ThreadContext->txHandlerCount++;         // Increment SendHandler count
+        // Build the packet in the send slot
+        pin->pinType->Send_Handler(ThreadContext->properties, device, pkt);
+        ThreadContext->txHandlerCount++;         // Increment SendHandler count
 #endif
-        }
-        //--------------------------------------------------------------------------
-
+    }
+    //--------------------------------------------------------------------------
+    
+    
+    if(pin->numEdges > 0)     // Sanity check: make sure the pin has edges
+    {
         //--------------------------------------------------------------------------
         // Set the addresses and send the packet
         //--------------------------------------------------------------------------
@@ -666,13 +668,13 @@ inline uint32_t softswitch_onRTS(ThreadCtxt_t* ThreadContext, devInst_t* device)
                                     ThreadContext->rtsStart))                  :
                             (ThreadContext->rtsStart - ThreadContext->rtsEnd);
                 
-                // If the pin has edges and there is space in the buffer
-                if(output_pin->numEdges && (buffRem > 1))
+                // If there is space in the buffer
+                if(buffRem > 1)                     //(output_pin->numEdges && )
                 {
                     //output_pin->sendPending++;
 #else
-                //If the pin has edges and is not already pending,
-                if(output_pin->numEdges && output_pin->sendPending == 0)
+                //If the pin is not already pending,
+                if(output_pin->sendPending == 0)    // output_pin->numEdges && 
                 {
                     // Flag that pin is pending
                     output_pin->sendPending = 1;


### PR DESCRIPTION
A small change in the Softswitch to fix #265. This (simply) changes the order of operations in the softswitch loop so that the pin target count occurs after OnSend has been called. RTS is also changed to remove the 0-edge guard that stopped unconnected pins appearing in the RTS list. Similar changes have been made for buffering mode.

There is a related examples PR with a simple test to check for correct behaviour: https://github.com/POETSII/Orchestrator_examples/pull/12.

Vol III B has been updated as well: 
[docx](https://github.com/POETSII/Orchestrator/files/6736912/Orch_Vol_IIIB_Softswitches_Supervisor_and_Composer.docx)|
[pdf](https://github.com/POETSII/Orchestrator/files/6736920/Orch_Vol_IIIB_Softswitches_Supervisor_and_Composer.pdf)

Changes are to the flow charts on Page 8 and 9, the flow chart on Page 11 and a bullet point on Page 10.

There is a previous unapproved change on Page 16 related to #263 

Please check tat you are happy and I will put the updated PDF in volumes without comments.

