### PR TITLE
Don't put 'typename' in macros under clang.

### DIFF
--- a/Generics/macros.h
+++ b/Generics/macros.h
@@ -10,7 +10,7 @@
 #define BYTESPERUNSIGNED 4
 
 #define TN typename
-#if (defined  _MSC_VER || defined __BORLANDC__)
+#if (defined  _MSC_VER || defined __BORLANDC__ || defined __clang__)
 #undef  TN
 #define TN
 #endif


### PR DESCRIPTION
Resolves #292 (which isn't a big problem, but eh).

Also paging @DrongoTheDog, because I found this while poking about with his memory checker experiment.