### PR TITLE
When we encounter an error from a bad packet from the backend input broker, don't keep going.

### DIFF
--- a/Config/OrchestratorMessages.ocfg
+++ b/Config/OrchestratorMessages.ocfg
@@ -516,8 +516,8 @@
 
 600(I) : "%s"
 601(I) : "Core %s: (part %s): %s"
-602(U) : "MLV: Allocated but as yet unused"
-603(U) : "MLV: Allocated but as yet unused"
+602(I) : "Sending a bad packet to Mothership at rank %s."
+603(E) : "Unable to send bad packet - can only do this in SINGLE_SUPERVISOR_MODE."
 604(U) : "MLV: Allocated but as yet unused"
 605(U) : "MLV: Allocated but as yet unused"
 606(U) : "MLV: Allocated but as yet unused"

--- a/Source/Mothership/ThreadLogic.cpp
+++ b/Source/Mothership/ThreadLogic.cpp
@@ -385,6 +385,7 @@ void* ThreadComms::backend_input_broker(void* mothershipArg)
                     if (appFinder == mothership->appdb.numberToApp.end())
                     {
                         mothership->Post(520, hex2str(appIt->first));
+                        continue;
                     }
 
                     /* Put the app name. */

--- a/Source/OrchBase/Handlers/CmTest.cpp
+++ b/Source/OrchBase/Handlers/CmTest.cpp
@@ -41,7 +41,7 @@ void CmTest::Cm_BadPacket()
     /* A packet. There's no payload. */
     uint8_t spoofTaskId = 63;
     P_Pkt_t badPacket;
-    set_pkt_hdr(1, 1, spoofTaskId, P_CNC_KILL, 0, 0, 0, 0, &badPacket.header);
+    set_pkt_hdr(1, 1, spoofTaskId, P_CNC_LOG, 0, 0, 0, 0, &badPacket.header);
     message.Put<P_Pkt_t>(0, &badPacket);
 
     /* Off we pop. */

--- a/Source/OrchBase/Handlers/CmTest.h
+++ b/Source/OrchBase/Handlers/CmTest.h
@@ -16,6 +16,7 @@ public:
               CmTest(OrchBase *);
 virtual ~     CmTest();
 
+void          Cm_BadPacket();
 void          Cm_Echo(Cli::Cl_t);
 void          Cm_Sleep(Cli::Cl_t);
 


### PR DESCRIPTION
Diagnosing #291 has been interesting. There are three places where a 520 message is posted:

 - When a `LOG` packet is consumed by the Mothership, and where the task ID of that packet doesn't match anything the Mothership knows about.
 - As above, but for a `KILL` packet.
 - When the Mothership receives a non-`CNC` packet (explicitly from the compute backend) with an invalid task ID.

I'm suspicious of the third one of these options as being the cause, but I also wanted to eliminate the first two as possibilities. I added a `test /badpacket` command, which sends a packet that triggers the first of the above three execution pathways (and can, with little adaption, trigger the second). On testing this (on Byron), I could not reproduce the error in #291.

Having ruled out the former two, I needed to deliberately send an invalid packet from the Softswitch to the Mothership. I made this change to `softswitch_common.cpp`:

```
@@ -434,6 +434,7 @@ inline uint32_t softswitch_onSend(ThreadCtxt_t* ThreadContext, volatile void* se

         if(hdr->swAddr & P_SW_MOTHERSHIP_MASK)
         {   // Message to the Supervisor or External (this goes via the Supervisor)
+            hdr->swAddr |= ((63 << P_SW_TASK_SHIFT) & P_SW_TASK_MASK);  // MLV
             SUPER_SEND(send_buf);  // Goes to the tinselHost
             ThreadContext->superCount++;         // Increment Supervisor Pkt count
         }
```

where `63` is identical to the erroneous value found in #291. With this change, I was able to reproduce the issue. The segmentation fault is triggered by `ThreadLogic.cpp:NL292`, where the value of an `end` iterator is requested. The fix is simple - once we've warned the operator of a bad packet via a 520 message, just drop it and don't attempt to process it.

In summary, this changeset:

 - Adds a test command, which sends a "bad" logging packet to a Mothership (only in single-supervisor mode).
 - Makes the backend input broker not fall over when it receives a CNC packet with a bad task ID (which resolves #291)

Also see the documentation PR at https://github.com/POETSII/orchestrator-documentation/pull/24.