### PR TITLE
Add pthread mutex to protect SuperDB::supervisors map from thread-unsafe modification.

### DIFF
--- a/Build/gcc/Makefile
+++ b/Build/gcc/Makefile
@@ -142,6 +142,7 @@ include Makefile.test_prerequisites
 TEST_SCRIPT_BASENAME = run-tests.sh
 TEST_SCRIPT = $(TEST_EXECUTABLE_DIR)/$(TEST_SCRIPT_BASENAME)
 tests: CXXFLAGS += $(DEBUGFLAGS)
+tests: POSTLINKFLAGS += $(SANITIZEFLAGS)
 tests: $(ALL_TESTS) $(TEST_SCRIPT)
 
 # Linking targets (to generate executables). See

--- a/Build/gcc/Makefile
+++ b/Build/gcc/Makefile
@@ -95,11 +95,19 @@ INCLUDE_FLAGS = -I$(GENERICS_DIR) \
 CXXFLAGS = $(DEPENDENCY_FLAGS) $(INCLUDE_FLAGS) \
            -std=c++98 -Wall -fPIC -pthread -pedantic -O3 -DTRIVIAL_LOG_HANDLER
 
+# Sanitize flags (used only during debugging)
+SANITIZEFLAGS = -fsanitize=address -fsanitize=undefined \
+                -fno-sanitize=alignment  # Msg_p uses these deliberately
+
 # Debugging!
-DEBUGFLAGS = -g3 -O0
+DEBUGFLAGS = -g3 -O0 $(SANITIZEFLAGS)
+
+# Flags on top of default linking flags used in rules.
+POSTLINKFLAGS =
 
 # Debug target logic.
 debug: CXXFLAGS += $(DEBUGFLAGS) -DORCHESTRATOR_DEBUG=1
+debug: POSTLINKFLAGS += $(SANITIZEFLAGS)
 debug: all
 
 # Handy aliases for building executables, scripts, and libraries. Order doesn't
@@ -144,19 +152,22 @@ $(LOGSERVER_EXECUTABLE) $(RTCL_EXECUTABLE) $(INJECTOR_EXECUTABLE):
 	@$(shell $(MKDIR) $(EXECUTABLE_DIR))
 	$(CXX) -pthread -L$(MPICH_LIB_DIR) -L/usr/lib \
         -o $@ $^ \
-        -lmpi -lpthread
+        -lmpi -lpthread \
+        $(POSTLINKFLAGS)
 
 $(ALL_TESTS):
 	@$(shell $(MKDIR) $(TEST_EXECUTABLE_DIR))
 	$(CXX) -pthread -L$(MPICH_LIB_DIR) -L/usr/lib \
         -o $@ $^ \
-        -lmpi -lpthread
+        -lmpi -lpthread \
+        $(POSTLINKFLAGS)
 
 $(MOTHERSHIP_EXECUTABLE):
 	@$(shell $(MKDIR) $(EXECUTABLE_DIR))
 	$(CXX) -pthread -Wl,-export-dynamic -L$(MPICH_LIB_DIR) -L/usr/lib \
         -o $@ $^ $(TINSEL_HOSTLINK_DIR)/*.o \
-        -lmpi -lpthread -ldl
+        -lmpi -lpthread -ldl \
+        $(POSTLINKFLAGS)
 
 # Object generation. Note: The move command installs the assembled dependency
 # file (see *Note 1*). The touch updates the timestamp on the target (to avoid

--- a/Build/gcc/Makefile.executable_prerequisites
+++ b/Build/gcc/Makefile.executable_prerequisites
@@ -52,6 +52,7 @@ HARDWARE_MODEL_SOURCES = $(SOURCE_DIR)/OrchBase/HardwareModel/AddressableItem.cp
                          $(SOURCE_DIR)/OrchBase/HardwareModel/P_thread.cpp \
                          $(SOURCE_DIR)/OrchBase/HardwareModel/P_link.cpp \
                          $(SOURCE_DIR)/OrchBase/HardwareModel/P_port.cpp \
+                         $(SOURCE_DIR)/OrchBase/AppStructures/Meta_t.cpp \
                          $(SOURCE_DIR)/Common/DumpUtils.cpp \
                          $(GENERICS_DIR)/NameBase.cpp \
                          $(GENERICS_DIR)/rand.cpp \

--- a/Source/Mothership/SuperDB.cpp
+++ b/Source/Mothership/SuperDB.cpp
@@ -1,6 +1,10 @@
 #include "SuperDB.h"
 
-SuperDB::SuperDB(){nextIdle = supervisors.begin();}
+SuperDB::SuperDB()
+{
+    pthread_mutex_init(&mapLock, NULL);
+    nextIdle = supervisors.begin();
+}
 
 /* Cleanup. */
 SuperDB::~SuperDB()
@@ -11,6 +15,7 @@ SuperDB::~SuperDB()
          superIt++) delete superIt->second;
     supervisors.clear();
     nextIdle = supervisors.begin();
+    pthread_mutex_destroy(&mapLock);
 }
 
 /* Gets the next supervisor in the idle rotation. Returns PNULL if there is no
@@ -18,8 +23,15 @@ SuperDB::~SuperDB()
  * locked, and that the application is running.*/
 SuperHolder* SuperDB::get_next_idle(std::string& name)
 {
+    pthread_mutex_lock(&mapLock);
+    SuperHolder* out;
+
     /* Protect against having no defined supervisors. */
-    if (supervisors.empty()) return PNULL;
+    if (supervisors.empty())
+    {
+        pthread_mutex_unlock(&mapLock);
+        return PNULL;
+    }
 
     /* Get next supervisor, ignoring supervisors with errors or supervisors
      * that have been freed. */
@@ -39,7 +51,9 @@ SuperHolder* SuperDB::get_next_idle(std::string& name)
     }
 
     name = nextIdle->first;
-    return nextIdle->second;
+    out = nextIdle->second;
+    pthread_mutex_unlock(&mapLock);
+    return out;
 }
 
 /* Retrieves a reference to the api-communications object used by the
@@ -70,8 +84,10 @@ bool SuperDB::load_supervisor(std::string appName, std::string path,
     }
 
     /* Otherwise, load up. */
+    pthread_mutex_lock(&mapLock);
     supervisors[appName] = new SuperHolder(path, appName);
     nextIdle = supervisors.begin();
+    pthread_mutex_unlock(&mapLock);
 
     /* Check for errors as per the specification... */
     if (supervisors.find(appName)->second->error)
@@ -90,8 +106,7 @@ bool SuperDB::load_supervisor(std::string appName, std::string path,
 bool SuperDB::reload_supervisor(std::string appName, std::string* errorMessage)
 {
     /* Before unloading the supervisor, get the path to the binary. */
-    std::string binPath =supervisors.find(appName)->second->path;
-
+    std::string binPath = supervisors.find(appName)->second->path;
     if (not unload_supervisor(appName)) return false;
     return load_supervisor(appName, binPath, errorMessage);
 }
@@ -103,13 +118,11 @@ bool SuperDB::unload_supervisor(std::string appName)
     /* Check whether or not a supervisor has already been loaded for this
      * application. */
     SuperIt superIt = supervisors.find(appName);
-    if (superIt == supervisors.end())
-    {
-        return false;
-    }
+    if (superIt == supervisors.end()) return false;
 
     /* Otherwise, unload away (via destructor), but let it finish what it's
      * doing. */
+    pthread_mutex_lock(&mapLock);
     pthread_mutex_t* superLock = &(superIt->second->lock);
     pthread_mutex_lock(superLock);
     SuperHolder* toDestroy = superIt->second;
@@ -117,6 +130,7 @@ bool SuperDB::unload_supervisor(std::string appName)
     nextIdle = supervisors.begin();
     pthread_mutex_unlock(superLock);
     delete toDestroy;
+    pthread_mutex_unlock(&mapLock);
     return true;
 }
 

--- a/Source/Mothership/SuperDB.h
+++ b/Source/Mothership/SuperDB.h
@@ -58,6 +58,7 @@ HANDLE_SUPERVISOR_DECL(exit)
 HANDLE_SUPERVISOR_DECL(idle)
 
 private:
+    pthread_mutex_t mapLock;
     std::map<std::string, SuperHolder*> supervisors;
     std::map<std::string, SuperHolder*>::iterator nextIdle;
 };


### PR DESCRIPTION
Resolves #290.

The intermittent segmentation fault reported in #290 was a Mothership segmentation fault, which occured when a supervisor was deleted from the supervisor map, and the iterator `SuperDB::nextIdle` was incremented simultaneously. A pthread mutex `SuperDB::mapLock` has been added to prevent this.

GCC's various instrumentation flags have been instrumental in diagnosing this issue, as the segmentation fault never triggered in debug mode, or when run under Valgrind. As such, a set of generally-useful instrumentation flags have been added to the debug build. These can be added to the performance build when needed, though this is not the default as they incur a (admittedly miniscule) performance penalty.

The segmentation fault did not occur, after implementing this change, running the same example repeatedly on Ayres for six hours.