### PR TITLE
Better handling for invalid inputs in test /sleep

### DIFF
--- a/Source/OrchBase/Handlers/CmTest.cpp
+++ b/Source/OrchBase/Handlers/CmTest.cpp
@@ -81,7 +81,8 @@ void CmTest::Cm_Sleep(Cli::Cl_t cl)
 // Pass an unsigned integer, we kip for a bit. Pass something else, nothing
 // will happen (probably).
 {
-    OSFixes::sleep(str2uint(cl.Pa_v.begin()->Concatenate()));
+    if (cl.Pa_v.empty()) return;
+    OSFixes::sleep(str2uint(cl.Pa_v.begin()->Concatenate(), 0));
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Resolves  #313 

For added panache, explicitly deals with stupidity like `test /sleep = "Until the cows come home"`.