### PR TITLE
Address "impossible-to-reach" GCC warning, with an appropriate else.

### DIFF
--- a/Config/OrchestratorMessages.ocfg
+++ b/Config/OrchestratorMessages.ocfg
@@ -670,7 +670,7 @@
 947(U) : "GMB: Allocated but as yet unused"
 948(U) : "GMB: Allocated but as yet unused"
 949(U) : "GMB: Allocated but as yet unused"
-950(U) : "MLV: Allocated but as yet unused"
+950(U) : "[%s] CommonBase::OnSystPingAck: Received message with no field in index zero."
 951(U) : "MLV: Allocated but as yet unused"
 952(U) : "MLV: Allocated but as yet unused"
 953(U) : "MLV: Allocated but as yet unused"

--- a/Config/OrchestratorMessages.ocfg
+++ b/Config/OrchestratorMessages.ocfg
@@ -670,7 +670,7 @@
 947(U) : "GMB: Allocated but as yet unused"
 948(U) : "GMB: Allocated but as yet unused"
 949(U) : "GMB: Allocated but as yet unused"
-950(U) : "[%s] CommonBase::OnSystPingAck: Received message with no field in index zero."
+950(U) : "[%s] CommonBase::OnSystPingAck: Received message with no <int> index zero field."
 951(U) : "MLV: Allocated but as yet unused"
 952(U) : "MLV: Allocated but as yet unused"
 953(U) : "MLV: Allocated but as yet unused"

--- a/Source/Common/CommonBase.cpp
+++ b/Source/Common/CommonBase.cpp
@@ -161,6 +161,11 @@ double trip = Z->Ztime(1)-ZT0;         // Round trip time
 int * pTgtR = Z->Get<int>(0,cnt);      // Unload target rank
 int TgtR;                              // Target rank
 if (pTgtR!=0) TgtR = * pTgtR;
+else                                   // Can't happen, post unrecoverable
+{
+Post(950,Sderived);
+return 0;
+}
 string TgtS = pPmap->M[TgtR];          // Target name
 const unsigned len = 20;               // Process name length
 TgtS.resize(len,' ');                  // So they line up on the console


### PR DESCRIPTION
Resolves #317.